### PR TITLE
HW1 (CS522): Lean port of Ex. 56 big-step + Ex. 70 small-step div-by-zero

### DIFF
--- a/Imp.lean
+++ b/Imp.lean
@@ -1,1 +1,2 @@
 import Imp.main
+import Imp.HW1

--- a/Imp/HW1.lean
+++ b/Imp/HW1.lean
@@ -1,0 +1,26 @@
+import Imp.HW1.Syntax
+import Imp.HW1.BigStep
+import Imp.HW1.SmallStep
+
+/-!
+# CS522 HW1 — aggregate module
+
+Re-exports the three HW1 sub-modules:
+
+* `Imp.HW1.Syntax`   — AST (with `Aexp.errorAr`, `Bexp.errorBool`,
+  `Stmt.errorStmt` constants per Ex. 70) and `State`.
+* `Imp.HW1.BigStep`  — Exercise 56: big-step `evalA / evalB / evalS / evalP`
+  with an `.err` value constructor at each sort.
+* `Imp.HW1.SmallStep`— Exercise 70: one-step `stepA / stepB / stepS` and
+  their reflexive-transitive closures, in the same namespace as Big-Step
+  so both can be used side-by-side.
+
+Source Maude files live in `brando90/cs522` at `master:694db12`, paths:
+* `HW1-Maude/imp/0-imp-original/imp-syntax.maude`
+* `HW1-Maude/imp/0-imp-original/1-imp-bigstep/imp-semantics-bigstep.maude`
+* `HW1-Maude/imp/0-imp-original/3-imp-smallstep/imp-semantics-smallstep.maude`
+
+The narrative and design choices are documented in
+`cs522/HW1-Maude/README.md` (course-side) and at the top of each Lean
+module below.
+-/

--- a/Imp/HW1/BigStep.lean
+++ b/Imp/HW1/BigStep.lean
@@ -1,0 +1,212 @@
+import Imp.HW1.Syntax
+
+/-!
+# CS522 HW1 — Exercise 56: big-step semantics with division-by-zero
+
+Faithful Lean 4 port of
+`brando90/cs522:HW1-Maude/imp/0-imp-original/1-imp-bigstep/imp-semantics-bigstep.maude`
+(modified version, with Error propagation).
+
+Modelling decisions:
+
+* Maude has three result configuration shapes for each sort: the pure
+  `< I >`, `< T >`, `< Sigma >` (values) and the pure `< Error >`. We
+  represent each sort's result as a small inductive "value" type,
+  `AVal | BVal | SVal`, where the `.err` constructor corresponds to the
+  Maude `< Error >` configuration.
+* The course-provided state `Sigma` is a total/partial map; we use
+  `Imp.HW1.State = Id → Option Int`. Maude's `Error : -> State` is modelled
+  separately via `SVal.err`, not by extending `State`.
+* Each Maude rule becomes an inductive constructor. Constructor names
+  mirror the rule names used in the Maude comments (e.g. `BigStep-DIV` →
+  `evalA.div`, `evalA.div_zero`, `evalA.div_err_l`, `evalA.div_err_r`).
+-/
+
+namespace Imp.HW1
+
+/-- Arithmetic big-step result: either an integer value or the pure
+`< Error >` configuration. -/
+inductive AVal where
+  | num : Int → AVal
+  | err : AVal
+deriving Repr, DecidableEq
+
+/-- Boolean big-step result. -/
+inductive BVal where
+  | bool : Bool → BVal
+  | err  : BVal
+deriving Repr, DecidableEq
+
+/-- Statement big-step result: either a final state or pure error. -/
+inductive SVal where
+  | state : State → SVal
+  | err   : SVal
+
+/-- Program-level big-step result. -/
+inductive PVal where
+  | state : State → PVal
+  | err   : PVal
+
+/-! ## Big-step evaluation of arithmetic expressions -/
+
+/-- `evalA a σ v` corresponds to the Maude sequent `< a, σ > => < v >`. -/
+inductive evalA : Aexp → State → AVal → Prop
+  /-- `BigStep-Int` — integer literal. -/
+  | const (n : Int) (σ : State) : evalA (.const n) σ (.num n)
+  /-- `BigStep-Lookup` — defined variable. -/
+  | var_ok {σ : State} {X : Id} {n : Int} (h : σ X = some n) :
+      evalA (.var X) σ (.num n)
+  /-- `BigStep-ADD` — normal case. -/
+  | add {a1 a2 : Aexp} {σ : State} {n1 n2 : Int}
+      (h1 : evalA a1 σ (.num n1)) (h2 : evalA a2 σ (.num n2)) :
+      evalA (.add a1 a2) σ (.num (n1 + n2))
+  /-- `BigStep-ADD` error propagation (left). -/
+  | add_err_l {a1 a2 : Aexp} {σ : State}
+      (h : evalA a1 σ .err) : evalA (.add a1 a2) σ .err
+  /-- `BigStep-ADD` error propagation (right). -/
+  | add_err_r {a1 a2 : Aexp} {σ : State}
+      (h : evalA a2 σ .err) : evalA (.add a1 a2) σ .err
+  /-- `BigStep-DIV` — normal case, divisor non-zero. (Maude: `I2 =/=Bool 0`) -/
+  | div {a1 a2 : Aexp} {σ : State} {n1 n2 : Int}
+      (h1 : evalA a1 σ (.num n1)) (h2 : evalA a2 σ (.num n2)) (hne : n2 ≠ 0) :
+      evalA (.div a1 a2) σ (.num (n1 / n2))
+  /-- **Ex. 56 headline rule** — division-by-zero yields `< Error >`.
+  Maude: `crl < A1 / A2 , Sigma > => < Error > if < A2,Sigma > => < 0 > .` -/
+  | div_zero {a1 a2 : Aexp} {σ : State} {n1 : Int}
+      (h1 : evalA a1 σ (.num n1)) (h2 : evalA a2 σ (.num 0)) :
+      evalA (.div a1 a2) σ .err
+  /-- `BigStep-DIV` error propagation (left operand evaluates to Error). -/
+  | div_err_l {a1 a2 : Aexp} {σ : State}
+      (h : evalA a1 σ .err) : evalA (.div a1 a2) σ .err
+  /-- `BigStep-DIV` error propagation (right operand evaluates to Error). -/
+  | div_err_r {a1 a2 : Aexp} {σ : State}
+      (h : evalA a2 σ .err) : evalA (.div a1 a2) σ .err
+
+/-! ## Big-step evaluation of boolean expressions -/
+
+/-- `evalB b σ v` — Maude: `< b, σ > => < v >`. -/
+inductive evalB : Bexp → State → BVal → Prop
+  /-- `BigStep-Bool` — boolean literal. -/
+  | b (v : Bool) (σ : State) : evalB (.b v) σ (.bool v)
+  /-- `BigStep-LEQ` — normal case. Maude uses sequential strictness on arguments. -/
+  | le {a1 a2 : Aexp} {σ : State} {n1 n2 : Int}
+      (h1 : evalA a1 σ (.num n1)) (h2 : evalA a2 σ (.num n2)) :
+      evalB (.le a1 a2) σ (.bool (decide (n1 ≤ n2)))
+  /-- `BigStep-LEQ` error propagation (left). -/
+  | le_err_l {a1 a2 : Aexp} {σ : State}
+      (h : evalA a1 σ .err) : evalB (.le a1 a2) σ .err
+  /-- `BigStep-LEQ` error propagation (right). -/
+  | le_err_r {a1 a2 : Aexp} {σ : State}
+      (h : evalA a2 σ .err) : evalB (.le a1 a2) σ .err
+  /-- `BigStep-Not-True`. -/
+  | not_t {b : Bexp} {σ : State}
+      (h : evalB b σ (.bool true)) : evalB (.not b) σ (.bool false)
+  /-- `BigStep-Not-False`. -/
+  | not_f {b : Bexp} {σ : State}
+      (h : evalB b σ (.bool false)) : evalB (.not b) σ (.bool true)
+  /-- `BigStep-Not` error propagation. -/
+  | not_err {b : Bexp} {σ : State}
+      (h : evalB b σ .err) : evalB (.not b) σ .err
+  /-- `BigStep-And-False` — short-circuit on false. -/
+  | and_false {b1 b2 : Bexp} {σ : State}
+      (h : evalB b1 σ (.bool false)) : evalB (.and b1 b2) σ (.bool false)
+  /-- `BigStep-And-True` — continue to b2 when b1 is true. -/
+  | and_true {b1 b2 : Bexp} {σ : State} {v : Bool}
+      (h1 : evalB b1 σ (.bool true)) (h2 : evalB b2 σ (.bool v)) :
+      evalB (.and b1 b2) σ (.bool v)
+  /-- `BigStep-And` error on first operand. -/
+  | and_err_l {b1 b2 : Bexp} {σ : State}
+      (h : evalB b1 σ .err) : evalB (.and b1 b2) σ .err
+  /-- `BigStep-And` error on second operand (only when b1 evaluates to true;
+  otherwise the false short-circuit rule fires and erases b2). -/
+  | and_err_r {b1 b2 : Bexp} {σ : State}
+      (h1 : evalB b1 σ (.bool true)) (h2 : evalB b2 σ .err) :
+      evalB (.and b1 b2) σ .err
+
+/-! ## Big-step evaluation of statements -/
+
+/-- `evalS s σ v` — Maude: `< s, σ > => < v >`. -/
+inductive evalS : Stmt → State → SVal → Prop
+  /-- `BigStep-Empty-Block` — `skip` leaves the state unchanged. -/
+  | skip (σ : State) : evalS .skip σ (.state σ)
+  /-- `BigStep-ASGN` normal — only defined for declared variables
+  (`Sigma(X) =/=Bool undefined`). -/
+  | assign_ok {σ : State} {X : Id} {a : Aexp} {n : Int}
+      (hDecl : σ X ≠ none) (hA : evalA a σ (.num n)) :
+      evalS (.assign X a) σ (.state (σ.update X n))
+  /-- `BigStep-ASGN` error — RHS expression evaluates to Error. -/
+  | assign_err {σ : State} {X : Id} {a : Aexp}
+      (hDecl : σ X ≠ none) (hA : evalA a σ .err) :
+      evalS (.assign X a) σ .err
+  /-- `BigStep-SEQ` — normal case. -/
+  | seq_ok {s1 s2 : Stmt} {σ σ' σ'' : State}
+      (h1 : evalS s1 σ (.state σ')) (h2 : evalS s2 σ' (.state σ'')) :
+      evalS (.seq s1 s2) σ (.state σ'')
+  /-- `BigStep-SEQ` error in first statement. -/
+  | seq_err_l {s1 s2 : Stmt} {σ : State}
+      (h : evalS s1 σ .err) : evalS (.seq s1 s2) σ .err
+  /-- `BigStep-SEQ` error in second statement (after first succeeded). -/
+  | seq_err_r {s1 s2 : Stmt} {σ σ' : State}
+      (h1 : evalS s1 σ (.state σ')) (h2 : evalS s2 σ' .err) :
+      evalS (.seq s1 s2) σ .err
+  /-- `BigStep-IF-True`. -/
+  | ite_true {b : Bexp} {s1 s2 : Stmt} {σ : State} {r : SVal}
+      (hb : evalB b σ (.bool true)) (h : evalS s1 σ r) :
+      evalS (.ite b s1 s2) σ r
+  /-- `BigStep-IF-False`. -/
+  | ite_false {b : Bexp} {s1 s2 : Stmt} {σ : State} {r : SVal}
+      (hb : evalB b σ (.bool false)) (h : evalS s2 σ r) :
+      evalS (.ite b s1 s2) σ r
+  /-- `BigStep-IF` error in guard. -/
+  | ite_err_guard {b : Bexp} {s1 s2 : Stmt} {σ : State}
+      (h : evalB b σ .err) : evalS (.ite b s1 s2) σ .err
+  /-- `BigStep-While-False` — guard is false, loop terminates in place. -/
+  | while_false {b : Bexp} {s : Stmt} {σ : State}
+      (h : evalB b σ (.bool false)) : evalS (.while b s) σ (.state σ)
+  /-- `BigStep-While` — guard errors. -/
+  | while_err_guard {b : Bexp} {s : Stmt} {σ : State}
+      (h : evalB b σ .err) : evalS (.while b s) σ .err
+  /-- `BigStep-While-True` — guard true, unroll one iteration then continue.
+  Matches Maude: `if < B,Sigma > => < true > /\ < S while (B) S, Sigma > => < Sigma' >`. -/
+  | while_true {b : Bexp} {s : Stmt} {σ σ' : State}
+      (hb : evalB b σ (.bool true)) (h : evalS (.seq s (.while b s)) σ (.state σ')) :
+      evalS (.while b s) σ (.state σ')
+  /-- `BigStep-While-True` with error propagation from the unrolled body. -/
+  | while_err_body {b : Bexp} {s : Stmt} {σ : State}
+      (hb : evalB b σ (.bool true)) (h : evalS (.seq s (.while b s)) σ .err) :
+      evalS (.while b s) σ .err
+
+/-! ## Big-step evaluation of programs
+
+Corresponds to the Maude `BigStep-PGM` rule:
+
+```maude
+crl < int Xl ; S > => < Sigma > if < S,(Xl |-> 0) > => < Sigma > .
+crl < int Xl ; S > => < Error > if < S,(Xl |-> 0) > => < Error > .
+```
+-/
+inductive evalP : Pgm → PVal → Prop
+  | ok {xl : List Id} {s : Stmt} {σ : State}
+      (h : evalS s (State.initZero xl) (.state σ)) : evalP ⟨xl, s⟩ (.state σ)
+  | err {xl : List Id} {s : Stmt}
+      (h : evalS s (State.initZero xl) .err) : evalP ⟨xl, s⟩ .err
+
+/-! ## Smoke tests — concrete instances matching entries of `my_tests.m` -/
+
+section Smoke
+
+/-- `< 1 / 0 , .State > => < Error >` — canonical div-by-zero. -/
+example : evalA (.div (.const 1) (.const 0)) State.empty .err :=
+  evalA.div_zero (evalA.const 1 _) (evalA.const 0 _)
+
+/-- `< 6 / 2 , .State > => < 3 >`. -/
+example : evalA (.div (.const 6) (.const 2)) State.empty (.num 3) :=
+  evalA.div (evalA.const 6 _) (evalA.const 2 _) (by decide)
+
+/-- `< 3 + 3 / 0 , .State > => < Error >`. -/
+example : evalA (.add (.const 3) (.div (.const 3) (.const 0))) State.empty .err :=
+  evalA.add_err_r (evalA.div_zero (evalA.const 3 _) (evalA.const 0 _))
+
+end Smoke
+
+end Imp.HW1

--- a/Imp/HW1/BigStep.lean
+++ b/Imp/HW1/BigStep.lean
@@ -71,9 +71,10 @@ inductive evalA : Aexp → State → AVal → Prop
       (h1 : evalA a1 σ (.num n1)) (h2 : evalA a2 σ (.num n2)) (hne : n2 ≠ 0) :
       evalA (.div a1 a2) σ (.num (n1 / n2))
   /-- **Ex. 56 headline rule** — division-by-zero yields `< Error >`.
-  Maude: `crl < A1 / A2 , Sigma > => < Error > if < A2,Sigma > => < 0 > .` -/
-  | div_zero {a1 a2 : Aexp} {σ : State} {n1 : Int}
-      (h1 : evalA a1 σ (.num n1)) (h2 : evalA a2 σ (.num 0)) :
+  Maude does not require the numerator to evaluate first:
+  `crl < A1 / A2 , Sigma > => < Error > if < A2,Sigma > => < 0 > .` -/
+  | div_zero {a1 a2 : Aexp} {σ : State}
+      (h2 : evalA a2 σ (.num 0)) :
       evalA (.div a1 a2) σ .err
   /-- `BigStep-DIV` error propagation (left operand evaluates to Error). -/
   | div_err_l {a1 a2 : Aexp} {σ : State}
@@ -197,7 +198,7 @@ section Smoke
 
 /-- `< 1 / 0 , .State > => < Error >` — canonical div-by-zero. -/
 example : evalA (.div (.const 1) (.const 0)) State.empty .err :=
-  evalA.div_zero (evalA.const 1 _) (evalA.const 0 _)
+  evalA.div_zero (evalA.const 0 _)
 
 /-- `< 6 / 2 , .State > => < 3 >`. -/
 example : evalA (.div (.const 6) (.const 2)) State.empty (.num 3) :=
@@ -205,7 +206,12 @@ example : evalA (.div (.const 6) (.const 2)) State.empty (.num 3) :=
 
 /-- `< 3 + 3 / 0 , .State > => < Error >`. -/
 example : evalA (.add (.const 3) (.div (.const 3) (.const 0))) State.empty .err :=
-  evalA.add_err_r (evalA.div_zero (evalA.const 3 _) (evalA.const 0 _))
+  evalA.add_err_r (evalA.div_zero (evalA.const 0 _))
+
+/-- Maude's div-by-zero rule ignores the numerator entirely, so even an
+undefined numerator still yields `< Error >` once the divisor is `0`. -/
+example : evalA (.div (.var "x") (.const 0)) State.empty .err :=
+  evalA.div_zero (evalA.const 0 _)
 
 end Smoke
 

--- a/Imp/HW1/README.md
+++ b/Imp/HW1/README.md
@@ -1,0 +1,41 @@
+# CS522 HW1 in Lean 4
+
+Lean 4 port of CS522 Homework 1 — **Exercise 56** (big-step semantics
+with division-by-zero) and **Exercise 70** (small-step semantics with
+division-by-zero).
+
+## File map
+
+| File                         | Maps to (Maude)                                                                                 |
+|------------------------------|-------------------------------------------------------------------------------------------------|
+| `Imp/HW1/Syntax.lean`        | `HW1-Maude/imp/0-imp-original/imp-syntax.maude` + `HW1-Maude/imp/state.maude`                   |
+| `Imp/HW1/BigStep.lean`       | `HW1-Maude/imp/0-imp-original/1-imp-bigstep/imp-semantics-bigstep.maude`   (Ex. 56)             |
+| `Imp/HW1/SmallStep.lean`     | `HW1-Maude/imp/0-imp-original/3-imp-smallstep/imp-semantics-smallstep.maude` (Ex. 70)           |
+| `Imp/HW1.lean` (aggregate)   | —                                                                                               |
+
+## Design summary
+
+* **Big-step (Ex. 56).** The Maude solution adds `Error : -> State` and
+  "sink" rules that rewrite `< A | B | S , Error >` to `< Error >`. In
+  Lean we model error as a value constructor `AVal.err / BVal.err /
+  SVal.err` rather than as a state value, so `State : Id → Option Int`
+  stays a plain partial map. Rule names mirror the Maude rule labels
+  (e.g. `BigStep-DIV` → `evalA.div / .div_zero / .div_err_l / .div_err_r`).
+* **Small-step (Ex. 70).** The Maude solution adds syntactic error
+  constants `errorAr : -> AExp`, `errorBool : -> BExp`,
+  `errorStmt : -> Stmt`. We encode them directly as constructors in
+  `Aexp / Bexp / Stmt` in `Syntax.lean`. The error constants are
+  terminal (no outgoing `step` rule) which makes our `stepsA / stepsB /
+  stepsS` reflexive-transitive closures converge at an error, matching
+  Maude's `rew *` behaviour. The headline rule
+  `o < I1 / 0, σ > => < errorAr, σ >` lives at `stepA.div_by_zero`.
+
+## Verification status
+
+* `lake build` passes for this checkout.
+* Small concrete examples (`example : evalA (.div 1 0) ...`) serve as
+  smoke tests at the bottom of `BigStep.lean` and `SmallStep.lean`.
+* Maude execution on the original course files has **not** been run in
+  this PR (no local `maude`; Docker workflow deferred). Final behavioural
+  verification is requested from Stepan Nesterov per the CS522 translation
+  protocol.

--- a/Imp/HW1/README.md
+++ b/Imp/HW1/README.md
@@ -24,10 +24,9 @@ division-by-zero).
 * **Small-step (Ex. 70).** The Maude solution adds syntactic error
   constants `errorAr : -> AExp`, `errorBool : -> BExp`,
   `errorStmt : -> Stmt`. We encode them directly as constructors in
-  `Aexp / Bexp / Stmt` in `Syntax.lean`. The error constants are
-  terminal (no outgoing `step` rule) which makes our `stepsA / stepsB /
-  stepsS` reflexive-transitive closures converge at an error, matching
-  Maude's `rew *` behaviour. The headline rule
+  `Aexp / Bexp / Stmt` in `Syntax.lean`, and we also port Maude's
+  top-level `o < errorX, σ > => < errorX, .State >` sink rules via
+  `stepA.error_sink / stepB.error_sink / stepS.error_sink`. The headline rule
   `o < I1 / 0, σ > => < errorAr, σ >` lives at `stepA.div_by_zero`.
 
 ## Verification status

--- a/Imp/HW1/SmallStep.lean
+++ b/Imp/HW1/SmallStep.lean
@@ -1,0 +1,221 @@
+import Imp.HW1.Syntax
+
+/-!
+# CS522 HW1 — Exercise 70: small-step semantics with division-by-zero
+
+Faithful Lean 4 port of
+`brando90/cs522:HW1-Maude/imp/0-imp-original/3-imp-smallstep/imp-semantics-smallstep.maude`
+(modified version, with the three error constants).
+
+Modelling decisions:
+
+* Maude's `errorAr : -> AExp`, `errorBool : -> BExp`, `errorStmt : -> Stmt`
+  are modelled as the syntactic constructors `Aexp.errorAr`, `Bexp.errorBool`,
+  `Stmt.errorStmt` in `Imp/HW1/Syntax.lean`. They only appear as intermediate
+  reduction targets.
+* Three one-step relations (`stepA`, `stepB`, `stepS`) correspond to Maude's
+  `o < _, _ > => < _, _ >` at each sort, per Figures 3.14/3.15 of Grigore
+  Roșu's textbook.
+* The Maude small-step rewrite also models an "error sink" under `o_` so
+  that `rew *` converges — we realise it by making `errorAr`/`errorBool`/
+  `errorStmt` *terminal* (no further `step` rules out of them). The
+  transitive-closure `steps*A` below is the reflexive-transitive closure
+  of `stepA`, so runs that reach an error constant terminate there.
+-/
+
+namespace Imp.HW1.Small
+
+open Imp.HW1
+
+/-! ## One-step reductions
+
+One relation per sort, mirroring Maude's `o < _, _ > => < _, _ >` sequents.
+Constructor names follow the Maude rule names (`SmallStep-ADD`,
+`SmallStep-DIV`, etc.).
+-/
+
+/-- Arithmetic one-step: `stepA a σ a' σ'` ≅ Maude `o < a, σ > => < a', σ' >`.
+Note: σ' is rarely different from σ at the `AExp` sort (state changes only
+on assignment), but we keep the pairing for uniformity with the Maude shape.
+-/
+inductive stepA : Aexp → State → Aexp → State → Prop
+  /-- `SmallStep-Lookup` — defined variable. -/
+  | lookup {σ : State} {X : Id} {n : Int}
+      (h : σ X = some n) : stepA (.var X) σ (.const n) σ
+  /-- `SmallStep-ADD` — reduce left operand, success. -/
+  | add_l {a1 a1' a2 : Aexp} {σ : State}
+      (h : stepA a1 σ a1' σ) (hne : a1' ≠ .errorAr) :
+      stepA (.add a1 a2) σ (.add a1' a2) σ
+  /-- `SmallStep-ADD` — left operand errors. -/
+  | add_l_err {a1 a1' a2 : Aexp} {σ : State}
+      (h : stepA a1 σ a1' σ) (he : a1' = .errorAr) :
+      stepA (.add a1 a2) σ .errorAr σ
+  /-- `SmallStep-ADD` — reduce right operand, success. -/
+  | add_r {a1 a2 a2' : Aexp} {σ : State}
+      (h : stepA a2 σ a2' σ) (hne : a2' ≠ .errorAr) :
+      stepA (.add a1 a2) σ (.add a1 a2') σ
+  /-- `SmallStep-ADD` — right operand errors. -/
+  | add_r_err {a1 a2 a2' : Aexp} {σ : State}
+      (h : stepA a2 σ a2' σ) (he : a2' = .errorAr) :
+      stepA (.add a1 a2) σ .errorAr σ
+  /-- `SmallStep-ADD` axiom: value + value. -/
+  | add_axiom {n1 n2 : Int} {σ : State} :
+      stepA (.add (.const n1) (.const n2)) σ (.const (n1 + n2)) σ
+  /-- `SmallStep-DIV` — reduce left operand, success. -/
+  | div_l {a1 a1' a2 : Aexp} {σ : State}
+      (h : stepA a1 σ a1' σ) (hne : a1' ≠ .errorAr) :
+      stepA (.div a1 a2) σ (.div a1' a2) σ
+  /-- `SmallStep-DIV` — left operand errors. -/
+  | div_l_err {a1 a1' a2 : Aexp} {σ : State}
+      (h : stepA a1 σ a1' σ) (he : a1' = .errorAr) :
+      stepA (.div a1 a2) σ .errorAr σ
+  /-- `SmallStep-DIV` — reduce right operand, success. -/
+  | div_r {a1 a2 a2' : Aexp} {σ : State}
+      (h : stepA a2 σ a2' σ) (hne : a2' ≠ .errorAr) :
+      stepA (.div a1 a2) σ (.div a1 a2') σ
+  /-- `SmallStep-DIV` — right operand errors. -/
+  | div_r_err {a1 a2 a2' : Aexp} {σ : State}
+      (h : stepA a2 σ a2' σ) (he : a2' = .errorAr) :
+      stepA (.div a1 a2) σ .errorAr σ
+  /-- `SmallStep-DIV` axiom: value / value, non-zero — normal computation. -/
+  | div_axiom {n1 n2 : Int} {σ : State} (hne : n2 ≠ 0) :
+      stepA (.div (.const n1) (.const n2)) σ (.const (n1 / n2)) σ
+  /-- **Ex. 70 headline rule** — value / 0 reduces to `errorAr`.
+  Maude: `crl o < I1 / I2, Sigma > => < errorAr, Sigma > if I2 ==Bool 0 .` -/
+  | div_by_zero {n1 : Int} {σ : State} :
+      stepA (.div (.const n1) (.const 0)) σ .errorAr σ
+
+/-- Boolean one-step. -/
+inductive stepB : Bexp → State → Bexp → State → Prop
+  /-- `SmallStep-LEQ-ARG` — reduce left arithmetic operand. -/
+  | le_l {a1 a1' a2 : Aexp} {σ : State}
+      (h : stepA a1 σ a1' σ) (hne : a1' ≠ .errorAr) :
+      stepB (.le a1 a2) σ (.le a1' a2) σ
+  /-- `SmallStep-LEQ-ARG` — left arithmetic errors. -/
+  | le_l_err {a1 a1' a2 : Aexp} {σ : State}
+      (h : stepA a1 σ a1' σ) (he : a1' = .errorAr) :
+      stepB (.le a1 a2) σ .errorBool σ
+  /-- `SmallStep-LEQ-ARG` — reduce right arithmetic operand.
+  Note Maude requires the left to be a value first (strict left-to-right);
+  we faithfully encode that by requiring `I1 : Int` (`Aexp.const`) on the left. -/
+  | le_r {n1 : Int} {a2 a2' : Aexp} {σ : State}
+      (h : stepA a2 σ a2' σ) (hne : a2' ≠ .errorAr) :
+      stepB (.le (.const n1) a2) σ (.le (.const n1) a2') σ
+  /-- `SmallStep-LEQ-ARG` — right arithmetic errors. -/
+  | le_r_err {n1 : Int} {a2 a2' : Aexp} {σ : State}
+      (h : stepA a2 σ a2' σ) (he : a2' = .errorAr) :
+      stepB (.le (.const n1) a2) σ .errorBool σ
+  /-- `SmallStep-LEQ` axiom: value ≤ value. -/
+  | le_axiom {n1 n2 : Int} {σ : State} :
+      stepB (.le (.const n1) (.const n2)) σ (.b (decide (n1 ≤ n2))) σ
+  /-- `SmallStep-Not-Arg`. -/
+  | not_arg {b b' : Bexp} {σ : State}
+      (h : stepB b σ b' σ) (hne : b' ≠ .errorBool) :
+      stepB (.not b) σ (.not b') σ
+  /-- `SmallStep-Not-Arg` — body errors. -/
+  | not_arg_err {b b' : Bexp} {σ : State}
+      (h : stepB b σ b' σ) (he : b' = .errorBool) :
+      stepB (.not b) σ .errorBool σ
+  /-- `!true => false`. -/
+  | not_true {σ : State} : stepB (.not (.b true)) σ (.b false) σ
+  /-- `!false => true`. -/
+  | not_false {σ : State} : stepB (.not (.b false)) σ (.b true) σ
+  /-- `SmallStep-AND` — reduce left operand. -/
+  | and_l {b1 b1' b2 : Bexp} {σ : State}
+      (h : stepB b1 σ b1' σ) (hne : b1' ≠ .errorBool) :
+      stepB (.and b1 b2) σ (.and b1' b2) σ
+  /-- `SmallStep-AND` — left errors. -/
+  | and_l_err {b1 b1' b2 : Bexp} {σ : State}
+      (h : stepB b1 σ b1' σ) (he : b1' = .errorBool) :
+      stepB (.and b1 b2) σ .errorBool σ
+  /-- `false && b2 => false`. -/
+  | and_false {b2 : Bexp} {σ : State} : stepB (.and (.b false) b2) σ (.b false) σ
+  /-- `true && b2 => b2`. -/
+  | and_true {b2 : Bexp} {σ : State} : stepB (.and (.b true) b2) σ b2 σ
+
+/-- Statement one-step. -/
+inductive stepS : Stmt → State → Stmt → State → Prop
+  /-- `SmallStep-Assign` — reduce RHS, success. -/
+  | assign_red {X : Id} {a a' : Aexp} {σ : State}
+      (h : stepA a σ a' σ) (hne : a' ≠ .errorAr) :
+      stepS (.assign X a) σ (.assign X a') σ
+  /-- `SmallStep-Assign` — RHS errors. -/
+  | assign_err {X : Id} {a a' : Aexp} {σ : State}
+      (h : stepA a σ a' σ) (he : a' = .errorAr) :
+      stepS (.assign X a) σ .errorStmt σ
+  /-- `SmallStep-Assign` axiom: `X = I ;` — commits the value. -/
+  | assign_axiom {σ : State} {X : Id} {n : Int}
+      (hDecl : σ X ≠ none) :
+      stepS (.assign X (.const n)) σ .skip (σ.update X n)
+  /-- `SmallStep-SEQ` — reduce head, success. -/
+  | seq_head {s1 s1' s2 : Stmt} {σ σ' : State}
+      (h : stepS s1 σ s1' σ') (hne : s1' ≠ .errorStmt) :
+      stepS (.seq s1 s2) σ (.seq s1' s2) σ'
+  /-- `SmallStep-SEQ` — head errors. -/
+  | seq_head_err {s1 s1' s2 : Stmt} {σ σ' : State}
+      (h : stepS s1 σ s1' σ') (he : s1' = .errorStmt) :
+      stepS (.seq s1 s2) σ .errorStmt σ'
+  /-- `SmallStep-SEQ` axiom: `skip ; s2 => s2`.
+  Note: `SmallStep-Block` (`{s} => s`) has no counterpart here — our `Stmt`
+  grammar doesn't include an explicit block wrapper (Maude syntax does). -/
+  | seq_skip {s2 : Stmt} {σ : State} :
+      stepS (.seq .skip s2) σ s2 σ
+  /-- `SmallStep-IF` — reduce guard. -/
+  | ite_red {b b' : Bexp} {s1 s2 : Stmt} {σ : State}
+      (h : stepB b σ b' σ) (hne : b' ≠ .errorBool) :
+      stepS (.ite b s1 s2) σ (.ite b' s1 s2) σ
+  /-- `SmallStep-IF` — guard errors. -/
+  | ite_err {b b' : Bexp} {s1 s2 : Stmt} {σ : State}
+      (h : stepB b σ b' σ) (he : b' = .errorBool) :
+      stepS (.ite b s1 s2) σ .errorStmt σ
+  /-- `if(true) s1 else s2 => s1`. -/
+  | ite_true {s1 s2 : Stmt} {σ : State} :
+      stepS (.ite (.b true) s1 s2) σ s1 σ
+  /-- `if(false) s1 else s2 => s2`. -/
+  | ite_false {s1 s2 : Stmt} {σ : State} :
+      stepS (.ite (.b false) s1 s2) σ s2 σ
+  /-- `while b s => if b then (s ; while b s) else skip`. -/
+  | while_unfold {b : Bexp} {s : Stmt} {σ : State} :
+      stepS (.while b s) σ (.ite b (.seq s (.while b s)) .skip) σ
+
+/-! ## Transitive closures — Maude's `*` relation.
+
+Reflexive-transitive closure of each one-step relation. Because our error
+constants are terminal (no `stepA`/`stepB`/`stepS` rules out of them),
+these closures naturally halt once an error constant is reached, matching
+the Maude `rew *` convergence behaviour. -/
+
+inductive stepsA : Aexp → State → Aexp → State → Prop
+  | refl (a : Aexp) (σ : State) : stepsA a σ a σ
+  | cons {a a' a'' : Aexp} {σ σ' σ'' : State}
+      (h1 : stepA a σ a' σ') (h2 : stepsA a' σ' a'' σ'') : stepsA a σ a'' σ''
+
+inductive stepsB : Bexp → State → Bexp → State → Prop
+  | refl (b : Bexp) (σ : State) : stepsB b σ b σ
+  | cons {b b' b'' : Bexp} {σ σ' σ'' : State}
+      (h1 : stepB b σ b' σ') (h2 : stepsB b' σ' b'' σ'') : stepsB b σ b'' σ''
+
+inductive stepsS : Stmt → State → Stmt → State → Prop
+  | refl (s : Stmt) (σ : State) : stepsS s σ s σ
+  | cons {s s' s'' : Stmt} {σ σ' σ'' : State}
+      (h1 : stepS s σ s' σ') (h2 : stepsS s' σ' s'' σ'') : stepsS s σ s'' σ''
+
+/-! ## Smoke tests — mirror `my_tests_small.m` entries. -/
+
+section Smoke
+
+/-- `o < 4 / 0 , .State > => < errorAr, .State >`. -/
+example : stepA (.div (.const 4) (.const 0)) State.empty .errorAr State.empty :=
+  stepA.div_by_zero
+
+/-- `o < 4 / 2 , .State > => < 2, .State >`. -/
+example : stepA (.div (.const 4) (.const 2)) State.empty (.const 2) State.empty :=
+  stepA.div_axiom (by decide)
+
+/-- `o < 8 + 2 , .State > => < 10, .State >`. -/
+example : stepA (.add (.const 8) (.const 2)) State.empty (.const 10) State.empty :=
+  stepA.add_axiom
+
+end Smoke
+
+end Imp.HW1.Small

--- a/Imp/HW1/SmallStep.lean
+++ b/Imp/HW1/SmallStep.lean
@@ -82,6 +82,11 @@ inductive stepA : Aexp → State → Aexp → State → Prop
   | div_axiom {n1 n2 : Int} {σ : State} (hne : n2 ≠ 0) :
       stepA (.div (.const n1) (.const n2)) σ (.const (n1 / n2)) σ
   /-- **Ex. 70 headline rule** — value / 0 reduces to `errorAr`.
+  Small-step axiom requires BOTH operands as Int literals — a genuine
+  difference from big-step's `evalA.div_zero` (which can skip the numerator
+  because big-step collapses the whole term at once). In small-step any
+  non-literal numerator must first reduce via `div_l` / lookup / etc. before
+  this axiom fires — that is what stepwise semantics means.
   Maude: `crl o < I1 / I2, Sigma > => < errorAr, Sigma > if I2 ==Bool 0 .` -/
   | div_by_zero {n1 : Int} {σ : State} :
       stepA (.div (.const n1) (.const 0)) σ .errorAr σ
@@ -183,6 +188,12 @@ inductive stepS : Stmt → State → Stmt → State → Prop
   | while_unfold {b : Bexp} {s : Stmt} {σ : State} :
       stepS (.while b s) σ (.ite b (.seq s (.while b s)) .skip) σ
 
+/-- Program one-step: `stepP p p'`.
+Maude: `rl o < int Xl ; S > => < S, (Xl |-> 0) > .` -/
+inductive stepP : Pgm → Stmt → State → Prop
+  | init {xl : List Id} {s : Stmt} :
+      stepP ⟨xl, s⟩ s (State.initZero xl)
+
 /-! ## Transitive closures — Maude's `*` relation.
 
 Reflexive-transitive closure of each one-step relation. This records the same
@@ -204,6 +215,11 @@ inductive stepsS : Stmt → State → Stmt → State → Prop
   | refl (s : Stmt) (σ : State) : stepsS s σ s σ
   | cons {s s' s'' : Stmt} {σ σ' σ'' : State}
       (h1 : stepS s σ s' σ') (h2 : stepsS s' σ' s'' σ'') : stepsS s σ s'' σ''
+
+/-- Program-level transitive closure: one step to initialize, then many steps of the body. -/
+inductive stepsP : Pgm → Stmt → State → Prop
+  | steps {p : Pgm} {s : Stmt} {σ : State} {s' : Stmt} {σ' : State}
+      (h1 : stepP p s σ) (h2 : stepsS s σ s' σ') : stepsP p s' σ'
 
 /-! ## Smoke tests — mirror `my_tests_small.m` entries. -/
 

--- a/Imp/HW1/SmallStep.lean
+++ b/Imp/HW1/SmallStep.lean
@@ -16,11 +16,10 @@ Modelling decisions:
 * Three one-step relations (`stepA`, `stepB`, `stepS`) correspond to Maude's
   `o < _, _ > => < _, _ >` at each sort, per Figures 3.14/3.15 of Grigore
   Roșu's textbook.
-* The Maude small-step rewrite also models an "error sink" under `o_` so
-  that `rew *` converges — we realise it by making `errorAr`/`errorBool`/
-  `errorStmt` *terminal* (no further `step` rules out of them). The
-  transitive-closure `steps*A` below is the reflexive-transitive closure
-  of `stepA`, so runs that reach an error constant terminate there.
+* The Maude small-step rewrite also models a top-level "error sink" under
+  `o_`: `errorAr`/`errorBool`/`errorStmt` rewrite to themselves over
+  `.State`. We port those sink steps directly as `error_sink`
+  constructors, using `State.empty` for Maude's `.State`.
 -/
 
 namespace Imp.HW1.Small
@@ -39,6 +38,8 @@ Note: σ' is rarely different from σ at the `AExp` sort (state changes only
 on assignment), but we keep the pairing for uniformity with the Maude shape.
 -/
 inductive stepA : Aexp → State → Aexp → State → Prop
+  /-- `SmallStep-On-Errors` — top-level arithmetic error sink. -/
+  | error_sink (σ : State) : stepA .errorAr σ .errorAr State.empty
   /-- `SmallStep-Lookup` — defined variable. -/
   | lookup {σ : State} {X : Id} {n : Int}
       (h : σ X = some n) : stepA (.var X) σ (.const n) σ
@@ -87,6 +88,8 @@ inductive stepA : Aexp → State → Aexp → State → Prop
 
 /-- Boolean one-step. -/
 inductive stepB : Bexp → State → Bexp → State → Prop
+  /-- `SmallStep-On-Errors` — top-level boolean error sink. -/
+  | error_sink (σ : State) : stepB .errorBool σ .errorBool State.empty
   /-- `SmallStep-LEQ-ARG` — reduce left arithmetic operand. -/
   | le_l {a1 a1' a2 : Aexp} {σ : State}
       (h : stepA a1 σ a1' σ) (hne : a1' ≠ .errorAr) :
@@ -135,13 +138,15 @@ inductive stepB : Bexp → State → Bexp → State → Prop
 
 /-- Statement one-step. -/
 inductive stepS : Stmt → State → Stmt → State → Prop
+  /-- `SmallStep-On-Errors` — top-level statement error sink. -/
+  | error_sink (σ : State) : stepS .errorStmt σ .errorStmt State.empty
   /-- `SmallStep-Assign` — reduce RHS, success. -/
   | assign_red {X : Id} {a a' : Aexp} {σ : State}
       (h : stepA a σ a' σ) (hne : a' ≠ .errorAr) :
       stepS (.assign X a) σ (.assign X a') σ
   /-- `SmallStep-Assign` — RHS errors. -/
-  | assign_err {X : Id} {a a' : Aexp} {σ : State}
-      (h : stepA a σ a' σ) (he : a' = .errorAr) :
+  | assign_err {X : Id} {a a' : Aexp} {σ σ' : State}
+      (h : stepA a σ a' σ') (he : a' = .errorAr) :
       stepS (.assign X a) σ .errorStmt σ
   /-- `SmallStep-Assign` axiom: `X = I ;` — commits the value. -/
   | assign_axiom {σ : State} {X : Id} {n : Int}
@@ -180,10 +185,10 @@ inductive stepS : Stmt → State → Stmt → State → Prop
 
 /-! ## Transitive closures — Maude's `*` relation.
 
-Reflexive-transitive closure of each one-step relation. Because our error
-constants are terminal (no `stepA`/`stepB`/`stepS` rules out of them),
-these closures naturally halt once an error constant is reached, matching
-the Maude `rew *` convergence behaviour. -/
+Reflexive-transitive closure of each one-step relation. This records the same
+reachability graph induced by the Lean `stepA`/`stepB`/`stepS` rules, including
+the explicit top-level error sinks that reset the state component to
+`State.empty` as in the Maude `o_` relation. -/
 
 inductive stepsA : Aexp → State → Aexp → State → Prop
   | refl (a : Aexp) (σ : State) : stepsA a σ a σ

--- a/Imp/HW1/Syntax.lean
+++ b/Imp/HW1/Syntax.lean
@@ -1,0 +1,99 @@
+/-!
+# CS522 HW1 — IMP syntax (with division + error constants)
+
+Lean 4 port of the IMP abstract syntax used for CS522 Homework 1
+(Exercise 56 big-step division-by-zero + Exercise 70 small-step
+division-by-zero).
+
+The corresponding Maude files in `brando90/cs522` at `master:694db12` are:
+
+- `HW1-Maude/imp/0-imp-original/imp-syntax.maude`  — original IMP syntax
+- `HW1-Maude/imp/state.maude`                       — `State` module
+- `HW1-Maude/imp/0-imp-original/1-imp-bigstep/imp-semantics-bigstep.maude`
+  (Ex. 56 — adds the `Error : -> State` constant)
+- `HW1-Maude/imp/0-imp-original/3-imp-smallstep/imp-semantics-smallstep.maude`
+  (Ex. 70 — adds `errorAr : -> AExp`, `errorBool : -> BExp`,
+  `errorStmt : -> Stmt`)
+
+## Design choices in Lean
+
+* The big-step Maude solution uses `Error : -> State`, which in Lean we
+  model via a separate value domain (`AVal / BVal / SVal` in `BigStep.lean`)
+  rather than by extending `State`. This keeps `State : Id → Option Int` as
+  a total partial map and matches the textbook's "either a number-result
+  or a pure error-result" phrasing.
+* The small-step Maude solution introduces a syntactic error constant at
+  each sort. We model those faithfully by extending `Aexp`/`Bexp`/`Stmt`
+  with `errorAr`/`errorBool`/`errorStmt` constructors. They are only used
+  as intermediate terms in the `stepA / stepB / stepS` reductions, but
+  Ex. 56 / big-step never builds an error term syntactically — it uses
+  the value-level `AVal.err` constructors instead.
+-/
+
+namespace Imp.HW1
+
+/-- Program variable names — unconstrained strings, per the Maude spec. -/
+abbrev Id := String
+
+/-- Arithmetic expressions.
+
+Original course fragment: `Int`, `Id`, `_+_`, `_/_`. We add `errorAr` as a
+syntactic error constant so small-step (Ex. 70) can reduce a failed
+sub-expression to it. Big-step never needs to construct `errorAr` in syntax —
+it uses `AVal.err` in its value domain (see `BigStep.lean`). -/
+inductive Aexp where
+  | const   : Int → Aexp
+  | var     : Id  → Aexp
+  | add     : Aexp → Aexp → Aexp
+  | div     : Aexp → Aexp → Aexp
+  | errorAr : Aexp
+deriving Repr, DecidableEq
+
+/-- Boolean expressions. Add `errorBool` for Ex. 70. -/
+inductive Bexp where
+  | b         : Bool → Bexp
+  | le        : Aexp → Aexp → Bexp
+  | not       : Bexp → Bexp
+  | and       : Bexp → Bexp → Bexp
+  | errorBool : Bexp
+deriving Repr, DecidableEq
+
+/-- Statements. Add `errorStmt` for Ex. 70. The empty block `{}` of the
+course grammar becomes `skip` here. -/
+inductive Stmt where
+  | skip      : Stmt
+  | assign    : Id → Aexp → Stmt
+  | seq       : Stmt → Stmt → Stmt
+  | ite       : Bexp → Stmt → Stmt → Stmt
+  | while     : Bexp → Stmt → Stmt
+  | errorStmt : Stmt
+deriving Repr, DecidableEq
+
+/-- A complete IMP program: a list of declared variables and a body. Maude
+syntax: `int xl ; s`. -/
+structure Pgm where
+  vars : List Id
+  body : Stmt
+deriving Repr
+
+/-- Program state — partial map from variable names to integers.
+`none` models an undefined binding, matching Maude's `Sigma(X) = undefined`. -/
+abbrev State := Id → Option Int
+
+namespace State
+
+/-- Empty state — no variables bound. -/
+def empty : State := fun _ => none
+
+/-- Point-wise update `σ[n/X]`. -/
+def update (σ : State) (X : Id) (n : Int) : State :=
+  fun Y => if Y = X then some n else σ Y
+
+/-- Initialise a list of variables all to 0 (matches Maude's `Xl |-> 0`). -/
+def initZero : List Id → State
+  | []      => empty
+  | X :: Xs => (initZero Xs).update X 0
+
+end State
+
+end Imp.HW1

--- a/Imp/main.lean
+++ b/Imp/main.lean
@@ -1,3 +1,5 @@
+import Mathlib.Tactic
+
 /-!
 # IMP — core syntax and big-step semantics
 
@@ -15,8 +17,6 @@ plus the standard meta-theorems:
   `terminate_while` — inversion/introduction characterisations used as
   `simp` lemmas to drive concrete termination proofs.
 -/
-
-import Mathlib.Tactic
 
 namespace Imp
 
@@ -153,12 +153,12 @@ def equiv (c d : Com) : Prop := ∀ (σ τ : State), terminate σ c τ ↔ termi
 /-- `halt' σ c` : the run of `c` from `σ` terminates in *some* state. -/
 def halt' (σ : State) (c : Com) : Prop := ∃ τ : State, terminate σ c τ
 
+open Classical in
 /-- The output of running `c` from an `Option State`. `none` propagates as
 `none`; from `some σ`, returns `some τ` where `τ` is a `terminate`-successor
 if one exists (via classical choice), else `none`. `terminate_unique` makes
 the chosen `τ` unique up to propositional equality. Noncomputable because of
 `Classical.choose`. -/
-open Classical in
 noncomputable def output (σ' : Option State) (c : Com) : Option State := match σ' with
   | some σ => if p : halt' σ c then some (Classical.choose p) else none
   | none => none


### PR DESCRIPTION
## Summary

- Ports CS522 Homework 1 (Exercises 56 and 70) from Maude to Lean 4.
- `Imp/HW1/Syntax.lean` — IMP AST with the Ex. 70 error constants.
- `Imp/HW1/BigStep.lean` — Ex. 56 big-step with `.err` value constructors at each sort.
- `Imp/HW1/SmallStep.lean` — Ex. 70 small-step with `.div_by_zero` as the headline rule.
- `Imp/HW1/README.md` — Lean-to-Maude file mapping + design rationale.
- Also fixes two pre-existing build breakages in `Imp/main.lean` (module-docstring-before-import; docstring attached to `open ... in` instead of `def output`) so `lake build` completes cleanly.

Maude-side context is in `brando90/cs522@master` commit [`694db12`](https://github.com/brando90/cs522/commit/694db12) — static documentation pass over Brando's original Maude solution (Ex. 56 big-step + Ex. 70 small-step).

## Test plan

- [x] `lake build` completes successfully (3108 jobs).
- [x] Smoke examples in `BigStep.lean` and `SmallStep.lean` exercise the canonical div-by-zero cases: `< 1 / 0, .State > ⇓ < Error >`, `< 6 / 2, .State > ⇓ < 3 >`, `< 3 + 3 / 0, .State > ⇓ < Error >`, `o < 4 / 0, .State > => < errorAr, .State >`, `o < 8 + 2, .State > => < 10, .State >`.
- [ ] Behavioural verification against the Maude reference (`maude my_tests.m` / `my_tests_small.m`): **not run in this PR** — no local `maude` binary, Docker workflow deferred.
- [ ] Independent review requested from **Stepan Nesterov** (`stepurik@stanford.edu`) per the CS522 translation protocol in `experiments/02_do_all_cs522_in_Lean/prompt.md`.

## Why this matters (for reviewers unfamiliar with the project)

This is HW1 of a sequential CS522-to-Lean port (HW1 → HW2 → HW3 → HW4 → HW5 → HW6 → Extra-Credit), each landing as its own PR. The long-term goal, documented in the rewritten top-level `README.md`, is to scale from CS522's toy IMP language to a formally-verified, inside-Lean semantic compiler for a real programming language — improving on VariBench (vibe-translation gap), VariBench-DT (test-coverage gap), and Aeneas (unproven-translator gap).

## Mega QA plan

Per `~/agents-config/INDEX_RULES.md` Rule 10, this PR will go through the 3-stage sequential chain **CC → Codex → Gemini** before merge. Results posted as PR comments.