### PR TITLE
HW2 (CS522): Lean port of Ex. 83 denotational silent div-by-zero failure

### DIFF
--- a/Imp.lean
+++ b/Imp.lean
@@ -1,2 +1,3 @@
 import Imp.main
 import Imp.HW1
+import Imp.HW2

--- a/Imp/HW2.lean
+++ b/Imp/HW2.lean
@@ -9,9 +9,10 @@ Re-exports HW2's submodules:
 * `Imp.HW2.Syntax`        — IMP AST + `State` + the reserved `errId`
   "silent-failure" flag.
 * `Imp.HW2.Denotational`  — Exercise 83 denotational semantics:
-  `denA / denB / denS / denP`, where `denS` is a total relation and
-  division-by-zero inside a Stmt manifests as `State.markFailed σ` on
-  the output, matching the Maude solution's use of `σ & err |-> 1`.
+  `denA / denB / denS / denP`, where `denA`/`denB` distinguish ordinary
+  values, Ex. 83 `Error`, and plain `undefined`, and only the `Error`
+  cases inside a Stmt manifest as `State.markFailed σ`, matching the
+  Maude solution's use of `σ & err |-> 1`.
 
 Maude source: `brando90/cs522:HW2-Maude/imp/0-imp-original/4-imp-denotational/imp-semantics-denotational.maude`
 (commit [`ca03448`](https://github.com/brando90/cs522/commit/ca03448)

--- a/Imp/HW2.lean
+++ b/Imp/HW2.lean
@@ -1,0 +1,23 @@
+import Imp.HW2.Syntax
+import Imp.HW2.Denotational
+
+/-!
+# CS522 HW2 — aggregate module
+
+Re-exports HW2's submodules:
+
+* `Imp.HW2.Syntax`        — IMP AST + `State` + the reserved `errId`
+  "silent-failure" flag.
+* `Imp.HW2.Denotational`  — Exercise 83 denotational semantics:
+  `denA / denB / denS / denP`, where `denS` is a total relation and
+  division-by-zero inside a Stmt manifests as `State.markFailed σ` on
+  the output, matching the Maude solution's use of `σ & err |-> 1`.
+
+Maude source: `brando90/cs522:HW2-Maude/imp/0-imp-original/4-imp-denotational/imp-semantics-denotational.maude`
+(commit [`ca03448`](https://github.com/brando90/cs522/commit/ca03448)
+for the module-level docstring; rule logic matches the original).
+
+Paper exercises 80/81/82 (equivalence of `if ... s` vs `if(b){s1 s}else{s2 s}`,
+well-definedness of `w_k`, fixed-point characterization) are deliberately
+**not** formalized here; per the HW spec they belong in a PDF submission.
+-/

--- a/Imp/HW2/Denotational.lean
+++ b/Imp/HW2/Denotational.lean
@@ -1,0 +1,183 @@
+import Imp.HW2.Syntax
+
+/-!
+# CS522 HW2 — Exercise 83: denotational semantics with silent division-by-zero
+
+Faithful Lean 4 port of
+`brando90/cs522:HW2-Maude/imp/0-imp-original/4-imp-denotational/imp-semantics-denotational.maude`
+(Ex. 83 — "return a state like for correct programs" on division-by-zero,
+rather than `bottom`).
+
+## Modelling decisions
+
+* The Maude solution uses `funCPO / appCPO / fixCPO` from a CPO library
+  plus a distinguished `Error : -> State` constant for AExp/BExp and a
+  reserved `op err : -> Id .` flag for silent-failure at Stmt/Pgm level.
+* In Lean we model the denotation **relationally** rather than
+  functionally, matching the style of `Imp/main.lean`'s `terminate`.
+  This avoids the need to reproduce the CPO / `fixCPO` machinery and
+  still captures the silent-failure behaviour faithfully.
+* `denA : Aexp → State → Option Int → Prop` — `some n` = arithmetic value,
+  `none` = the Maude `Error` result. Same for `denB`.
+* `denS : Stmt → State → State → Prop` — a *total* relation (every
+  well-behaved program has a final state), with silent-failure encoded
+  by `State.isFailed σ` on the output. There is no "bottom" value here;
+  instead, non-termination is represented, as in `Imp/main.lean`, by the
+  *absence* of any derivation.
+* Constructor names mirror the Maude equation labels where possible.
+-/
+
+namespace Imp.HW2
+
+/-! ## Arithmetic-expression denotation -/
+
+inductive denA : Aexp → State → Option Int → Prop
+  /-- `[[I]] = funCPO σ → I`. -/
+  | const (n : Int) (σ : State) : denA (.const n) σ (some n)
+  /-- `[[X]] = funCPO σ → σ(X)` when σ(X) is defined. -/
+  | var_ok {σ : State} {X : Id} {n : Int} (h : σ X = some n) :
+      denA (.var X) σ (some n)
+  /-- Undefined variable lookup treated as `undefined`, lifted to Maude `Error`. -/
+  | var_err {σ : State} {X : Id} (h : σ X = none) :
+      denA (.var X) σ none
+  /-- `[[A1 + A2]]` normal case. -/
+  | add {a1 a2 : Aexp} {σ : State} {n1 n2 : Int}
+      (h1 : denA a1 σ (some n1)) (h2 : denA a2 σ (some n2)) :
+      denA (.add a1 a2) σ (some (n1 + n2))
+  /-- `[[A1 + A2]]` — left operand yields `Error`. -/
+  | add_err_l {a1 a2 : Aexp} {σ : State}
+      (h : denA a1 σ none) : denA (.add a1 a2) σ none
+  /-- `[[A1 + A2]]` — right operand yields `Error`. -/
+  | add_err_r {a1 a2 : Aexp} {σ : State}
+      (h : denA a2 σ none) : denA (.add a1 a2) σ none
+  /-- `[[A1 / A2]]` — normal case, divisor non-zero. -/
+  | div_ok {a1 a2 : Aexp} {σ : State} {n1 n2 : Int}
+      (h1 : denA a1 σ (some n1)) (h2 : denA a2 σ (some n2)) (hne : n2 ≠ 0) :
+      denA (.div a1 a2) σ (some (n1 / n2))
+  /-- **Ex. 83 headline rule at AExp level** — divisor is 0 ⇒ `Error`.
+  Maude: `ifCPO(appCPO([[A2]],σ) ==Bool 0, Error, ...)`. -/
+  | div_zero {a1 a2 : Aexp} {σ : State}
+      (h : denA a2 σ (some 0)) : denA (.div a1 a2) σ none
+  /-- `[[A1 / A2]]` — left operand is `Error`. -/
+  | div_err_l {a1 a2 : Aexp} {σ : State}
+      (h : denA a1 σ none) : denA (.div a1 a2) σ none
+  /-- `[[A1 / A2]]` — right operand is `Error`. -/
+  | div_err_r {a1 a2 : Aexp} {σ : State}
+      (h : denA a2 σ none) : denA (.div a1 a2) σ none
+
+/-! ## Boolean-expression denotation -/
+
+inductive denB : Bexp → State → Option Bool → Prop
+  /-- `[[T]] = funCPO σ → T`. -/
+  | b (v : Bool) (σ : State) : denB (.b v) σ (some v)
+  /-- `[[A1 <= A2]]` normal. -/
+  | le {a1 a2 : Aexp} {σ : State} {n1 n2 : Int}
+      (h1 : denA a1 σ (some n1)) (h2 : denA a2 σ (some n2)) :
+      denB (.le a1 a2) σ (some (decide (n1 ≤ n2)))
+  /-- `[[A1 <= A2]]` — left arithmetic yields `Error`. -/
+  | le_err_l {a1 a2 : Aexp} {σ : State}
+      (h : denA a1 σ none) : denB (.le a1 a2) σ none
+  /-- `[[A1 <= A2]]` — right arithmetic yields `Error`. -/
+  | le_err_r {a1 a2 : Aexp} {σ : State}
+      (h : denA a2 σ none) : denB (.le a1 a2) σ none
+  /-- `[[! B]]` normal. -/
+  | not {b : Bexp} {σ : State} {v : Bool}
+      (h : denB b σ (some v)) : denB (.not b) σ (some (!v))
+  /-- `[[! B]]` — operand is `Error`. -/
+  | not_err {b : Bexp} {σ : State}
+      (h : denB b σ none) : denB (.not b) σ none
+  /-- `[[B1 && B2]]` — short-circuits on false. -/
+  | and_false {b1 b2 : Bexp} {σ : State}
+      (h : denB b1 σ (some false)) : denB (.and b1 b2) σ (some false)
+  /-- `[[B1 && B2]]` — continue to b2 when b1 is true. -/
+  | and_true {b1 b2 : Bexp} {σ : State} {v : Bool}
+      (h1 : denB b1 σ (some true)) (h2 : denB b2 σ (some v)) :
+      denB (.and b1 b2) σ (some v)
+  /-- `[[B1 && B2]]` — first operand `Error`. -/
+  | and_err_l {b1 b2 : Bexp} {σ : State}
+      (h : denB b1 σ none) : denB (.and b1 b2) σ none
+  /-- `[[B1 && B2]]` — second operand `Error` (only when b1 is true). -/
+  | and_err_r {b1 b2 : Bexp} {σ : State}
+      (h1 : denB b1 σ (some true)) (h2 : denB b2 σ none) :
+      denB (.and b1 b2) σ none
+
+/-! ## Statement denotation — with silent failure (Ex. 83) -/
+
+inductive denS : Stmt → State → State → Prop
+  /-- `[[{}]] = funCPO σ → σ`. -/
+  | skip (σ : State) : denS .skip σ σ
+  /-- `[[X = A ;]]` — normal. Requires X to be declared, just like Maude's
+  `_`(_`)(σ, X) =/=Bool undefined` guard. -/
+  | assign_ok {σ : State} {X : Id} {a : Aexp} {n : Int}
+      (hDecl : σ X ≠ none) (hA : denA a σ (some n)) :
+      denS (.assign X a) σ (σ.update X n)
+  /-- **Silent-failure assignment** — Maude: if `[[A]](σ) == Error` then
+  commit to `σ & err |-> 1`. Every such Stmt has an output state. -/
+  | assign_err {σ : State} {X : Id} {a : Aexp}
+      (hA : denA a σ none) :
+      denS (.assign X a) σ σ.markFailed
+  /-- `[[S1 S2]]` — S1 fails silently, skip S2. Maude: `ifCPO(
+  _`(_`)(appCPO([[S1]],σ), err) ==Bool undefined, ..., appCPO([[S1]],σ))`. -/
+  | seq_failed {s1 s2 : Stmt} {σ σ' : State}
+      (h1 : denS s1 σ σ') (hFail : σ'.isFailed) :
+      denS (.seq s1 s2) σ σ'
+  /-- `[[S1 S2]]` — normal case. -/
+  | seq_ok {s1 s2 : Stmt} {σ σ' σ'' : State}
+      (h1 : denS s1 σ σ') (hOk : ¬ σ'.isFailed) (h2 : denS s2 σ' σ'') :
+      denS (.seq s1 s2) σ σ''
+  /-- `[[if (B) S1 else S2]]` — guard true. -/
+  | ite_true {b : Bexp} {s1 s2 : Stmt} {σ σ' : State}
+      (hb : denB b σ (some true)) (h : denS s1 σ σ') :
+      denS (.ite b s1 s2) σ σ'
+  /-- `[[if (B) S1 else S2]]` — guard false. -/
+  | ite_false {b : Bexp} {s1 s2 : Stmt} {σ σ' : State}
+      (hb : denB b σ (some false)) (h : denS s2 σ σ') :
+      denS (.ite b s1 s2) σ σ'
+  /-- **Silent-failure if** — guard errors ⇒ silently fail. Maude:
+  `ifCPO(appCPO([[B]],σ) ==Bool Error, σ & err |-> 1, ...)`. -/
+  | ite_err {b : Bexp} {s1 s2 : Stmt} {σ : State}
+      (hb : denB b σ none) : denS (.ite b s1 s2) σ σ.markFailed
+  /-- `[[while (B) S]]` — guard false ⇒ terminate. -/
+  | while_false {b : Bexp} {s : Stmt} {σ : State}
+      (hb : denB b σ (some false)) : denS (.while b s) σ σ
+  /-- `[[while (B) S]]` — guard true, body fails silently ⇒ absorb failure. -/
+  | while_body_failed {b : Bexp} {s : Stmt} {σ σ' : State}
+      (hb : denB b σ (some true)) (h : denS s σ σ') (hFail : σ'.isFailed) :
+      denS (.while b s) σ σ'
+  /-- `[[while (B) S]]` — guard true, body ok, continue. -/
+  | while_true {b : Bexp} {s : Stmt} {σ σ' σ'' : State}
+      (hb : denB b σ (some true)) (h : denS s σ σ') (hOk : ¬ σ'.isFailed)
+      (hLoop : denS (.while b s) σ' σ'') :
+      denS (.while b s) σ σ''
+  /-- **Silent-failure while-guard** — guard errors ⇒ fail silently. -/
+  | while_err {b : Bexp} {s : Stmt} {σ : State}
+      (hb : denB b σ none) : denS (.while b s) σ σ.markFailed
+
+/-! ## Program denotation -/
+
+/-- `[[(int Xl ; S)]] = appCPO([[S]], Xl |-> 0)`. -/
+inductive denP : Pgm → State → Prop
+  | run {xl : List Id} {s : Stmt} {σ : State}
+      (h : denS s (State.initZero xl) σ) : denP ⟨xl, s⟩ σ
+
+/-! ## Smoke tests — small instances of `my_test.maude` -/
+
+section Smoke
+
+/-- `[[1/0]](∅) = Error` — Maude `red appCPO([[1 / 0]], .State) .`. -/
+example : denA (.div (.const 1) (.const 0)) State.empty none :=
+  denA.div_zero (denA.const 0 _)
+
+/-- `[[6/2]](∅) = some 3`. -/
+example : denA (.div (.const 6) (.const 2)) State.empty (some 3) :=
+  denA.div_ok (denA.const 6 _) (denA.const 2 _) (by decide)
+
+/-- `[[x = 3/0 ;]](x|->2) = markFailed (x|->2)` — silent failure. -/
+example : denS (.assign "x" (.div (.const 3) (.const 0)))
+                 ((State.empty).update "x" 2)
+                 (((State.empty).update "x" 2).markFailed) :=
+  denS.assign_err (denA.div_zero (denA.const 0 _))
+
+end Smoke
+
+end Imp.HW2

--- a/Imp/HW2/Denotational.lean
+++ b/Imp/HW2/Denotational.lean
@@ -17,89 +17,161 @@ rather than `bottom`).
   functionally, matching the style of `Imp/main.lean`'s `terminate`.
   This avoids the need to reproduce the CPO / `fixCPO` machinery and
   still captures the silent-failure behaviour faithfully.
-* `denA : Aexp → State → Option Int → Prop` — `some n` = arithmetic value,
-  `none` = the Maude `Error` result. Same for `denB`.
-* `denS : Stmt → State → State → Prop` — a *total* relation (every
-  well-behaved program has a final state), with silent-failure encoded
-  by `State.isFailed σ` on the output. There is no "bottom" value here;
-  instead, non-termination is represented, as in `Imp/main.lean`, by the
-  *absence* of any derivation.
+* `denA : Aexp → State → AResult → Prop` and
+  `denB : Bexp → State → BResult → Prop` distinguish three Maude outcomes:
+  an ordinary value, the Ex. 83 `Error`, and ordinary `undefined`.
+* `denS : Stmt → State → State → Prop` only converts `Error` to a silent
+  failure state (`State.markFailed σ`). Plain `undefined` remains bottom,
+  as in the Maude equations.
 * Constructor names mirror the Maude equation labels where possible.
 -/
 
 namespace Imp.HW2
 
+/-! ## Result domains
+
+The Maude Ex. 83 solution introduces a distinct `Error : -> State` constant
+while still retaining the existing `undefined` bottom from the CPO library.
+We therefore model arithmetic and boolean denotations with three outcomes:
+
+* a normal value,
+* `error` for the Ex. 83 "division by zero" signal that statements turn into
+  `markFailed`,
+* `undef` for the pre-existing bottom produced by undeclared-variable lookups
+  and other partiality already present in the original semantics.
+-/
+
+/-- Arithmetic denotation result: value, Ex. 83 `Error`, or ordinary bottom. -/
+inductive AResult where
+  | val : Int → AResult
+  | error : AResult
+  | undef : AResult
+deriving Repr, DecidableEq
+
+/-- Boolean denotation result: value, Ex. 83 `Error`, or ordinary bottom. -/
+inductive BResult where
+  | val : Bool → BResult
+  | error : BResult
+  | undef : BResult
+deriving Repr, DecidableEq
+
 /-! ## Arithmetic-expression denotation -/
 
-inductive denA : Aexp → State → Option Int → Prop
+inductive denA : Aexp → State → AResult → Prop
   /-- `[[I]] = funCPO σ → I`. -/
-  | const (n : Int) (σ : State) : denA (.const n) σ (some n)
+  | const (n : Int) (σ : State) : denA (.const n) σ (.val n)
   /-- `[[X]] = funCPO σ → σ(X)` when σ(X) is defined. -/
   | var_ok {σ : State} {X : Id} {n : Int} (h : σ X = some n) :
-      denA (.var X) σ (some n)
-  /-- Undefined variable lookup treated as `undefined`, lifted to Maude `Error`. -/
-  | var_err {σ : State} {X : Id} (h : σ X = none) :
-      denA (.var X) σ none
+      denA (.var X) σ (.val n)
+  /-- Undefined variable lookup remains Maude `undefined`, not Ex. 83 `Error`. -/
+  | var_undef {σ : State} {X : Id} (h : σ X = none) :
+      denA (.var X) σ .undef
   /-- `[[A1 + A2]]` normal case. -/
   | add {a1 a2 : Aexp} {σ : State} {n1 n2 : Int}
-      (h1 : denA a1 σ (some n1)) (h2 : denA a2 σ (some n2)) :
-      denA (.add a1 a2) σ (some (n1 + n2))
+      (h1 : denA a1 σ (.val n1)) (h2 : denA a2 σ (.val n2)) :
+      denA (.add a1 a2) σ (.val (n1 + n2))
   /-- `[[A1 + A2]]` — left operand yields `Error`. -/
   | add_err_l {a1 a2 : Aexp} {σ : State}
-      (h : denA a1 σ none) : denA (.add a1 a2) σ none
+      (h : denA a1 σ .error) : denA (.add a1 a2) σ .error
   /-- `[[A1 + A2]]` — right operand yields `Error`. -/
   | add_err_r {a1 a2 : Aexp} {σ : State}
-      (h : denA a2 σ none) : denA (.add a1 a2) σ none
+      (h : denA a2 σ .error) : denA (.add a1 a2) σ .error
+  /-- `[[A1 + A2]]` — left operand is ordinary `undefined`, right is a value. -/
+  | add_undef_l_val {a1 a2 : Aexp} {σ : State} {n2 : Int}
+      (h1 : denA a1 σ .undef) (h2 : denA a2 σ (.val n2)) :
+      denA (.add a1 a2) σ .undef
+  /-- `[[A1 + A2]]` — both operands are ordinary `undefined`. -/
+  | add_undef_l_undef {a1 a2 : Aexp} {σ : State}
+      (h1 : denA a1 σ .undef) (h2 : denA a2 σ .undef) :
+      denA (.add a1 a2) σ .undef
+  /-- `[[A1 + A2]]` — right operand is ordinary `undefined`. -/
+  | add_undef_r {a1 a2 : Aexp} {σ : State} {n1 : Int}
+      (h1 : denA a1 σ (.val n1)) (h2 : denA a2 σ .undef) :
+      denA (.add a1 a2) σ .undef
   /-- `[[A1 / A2]]` — normal case, divisor non-zero. -/
   | div_ok {a1 a2 : Aexp} {σ : State} {n1 n2 : Int}
-      (h1 : denA a1 σ (some n1)) (h2 : denA a2 σ (some n2)) (hne : n2 ≠ 0) :
-      denA (.div a1 a2) σ (some (n1 / n2))
+      (h1 : denA a1 σ (.val n1)) (h2 : denA a2 σ (.val n2)) (hne : n2 ≠ 0) :
+      denA (.div a1 a2) σ (.val (n1 / n2))
   /-- **Ex. 83 headline rule at AExp level** — divisor is 0 ⇒ `Error`.
   Maude: `ifCPO(appCPO([[A2]],σ) ==Bool 0, Error, ...)`. -/
   | div_zero {a1 a2 : Aexp} {σ : State}
-      (h : denA a2 σ (some 0)) : denA (.div a1 a2) σ none
+      (h : denA a2 σ (.val 0)) : denA (.div a1 a2) σ .error
   /-- `[[A1 / A2]]` — left operand is `Error`. -/
   | div_err_l {a1 a2 : Aexp} {σ : State}
-      (h : denA a1 σ none) : denA (.div a1 a2) σ none
+      (h : denA a1 σ .error) : denA (.div a1 a2) σ .error
   /-- `[[A1 / A2]]` — right operand is `Error`. -/
   | div_err_r {a1 a2 : Aexp} {σ : State}
-      (h : denA a2 σ none) : denA (.div a1 a2) σ none
+      (h : denA a2 σ .error) : denA (.div a1 a2) σ .error
+  /-- `[[A1 / A2]]` — left operand is `undefined`, divisor is a non-zero value. -/
+  | div_undef_l_nonzero {a1 a2 : Aexp} {σ : State} {n2 : Int}
+      (h1 : denA a1 σ .undef) (h2 : denA a2 σ (.val n2)) (hne : n2 ≠ 0) :
+      denA (.div a1 a2) σ .undef
+  /-- `[[A1 / A2]]` — both operands are ordinary `undefined`. -/
+  | div_undef_l_undef {a1 a2 : Aexp} {σ : State}
+      (h1 : denA a1 σ .undef) (h2 : denA a2 σ .undef) :
+      denA (.div a1 a2) σ .undef
+  /-- `[[A1 / A2]]` — divisor is ordinary `undefined`. -/
+  | div_undef_r {a1 a2 : Aexp} {σ : State} {n1 : Int}
+      (h1 : denA a1 σ (.val n1)) (h2 : denA a2 σ .undef) :
+      denA (.div a1 a2) σ .undef
 
 /-! ## Boolean-expression denotation -/
 
-inductive denB : Bexp → State → Option Bool → Prop
+inductive denB : Bexp → State → BResult → Prop
   /-- `[[T]] = funCPO σ → T`. -/
-  | b (v : Bool) (σ : State) : denB (.b v) σ (some v)
+  | b (v : Bool) (σ : State) : denB (.b v) σ (.val v)
   /-- `[[A1 <= A2]]` normal. -/
   | le {a1 a2 : Aexp} {σ : State} {n1 n2 : Int}
-      (h1 : denA a1 σ (some n1)) (h2 : denA a2 σ (some n2)) :
-      denB (.le a1 a2) σ (some (decide (n1 ≤ n2)))
+      (h1 : denA a1 σ (.val n1)) (h2 : denA a2 σ (.val n2)) :
+      denB (.le a1 a2) σ (.val (decide (n1 ≤ n2)))
   /-- `[[A1 <= A2]]` — left arithmetic yields `Error`. -/
   | le_err_l {a1 a2 : Aexp} {σ : State}
-      (h : denA a1 σ none) : denB (.le a1 a2) σ none
+      (h : denA a1 σ .error) : denB (.le a1 a2) σ .error
   /-- `[[A1 <= A2]]` — right arithmetic yields `Error`. -/
   | le_err_r {a1 a2 : Aexp} {σ : State}
-      (h : denA a2 σ none) : denB (.le a1 a2) σ none
+      (h : denA a2 σ .error) : denB (.le a1 a2) σ .error
+  /-- `[[A1 <= A2]]` — left side is ordinary `undefined`, right is a value. -/
+  | le_undef_l_val {a1 a2 : Aexp} {σ : State} {n2 : Int}
+      (h1 : denA a1 σ .undef) (h2 : denA a2 σ (.val n2)) :
+      denB (.le a1 a2) σ .undef
+  /-- `[[A1 <= A2]]` — both sides are ordinary `undefined`. -/
+  | le_undef_l_undef {a1 a2 : Aexp} {σ : State}
+      (h1 : denA a1 σ .undef) (h2 : denA a2 σ .undef) :
+      denB (.le a1 a2) σ .undef
+  /-- `[[A1 <= A2]]` — right side is ordinary `undefined`. -/
+  | le_undef_r {a1 a2 : Aexp} {σ : State} {n1 : Int}
+      (h1 : denA a1 σ (.val n1)) (h2 : denA a2 σ .undef) :
+      denB (.le a1 a2) σ .undef
   /-- `[[! B]]` normal. -/
   | not {b : Bexp} {σ : State} {v : Bool}
-      (h : denB b σ (some v)) : denB (.not b) σ (some (!v))
+      (h : denB b σ (.val v)) : denB (.not b) σ (.val (!v))
   /-- `[[! B]]` — operand is `Error`. -/
   | not_err {b : Bexp} {σ : State}
-      (h : denB b σ none) : denB (.not b) σ none
+      (h : denB b σ .error) : denB (.not b) σ .error
+  /-- `[[! B]]` — operand is ordinary `undefined`. -/
+  | not_undef {b : Bexp} {σ : State}
+      (h : denB b σ .undef) : denB (.not b) σ .undef
   /-- `[[B1 && B2]]` — short-circuits on false. -/
   | and_false {b1 b2 : Bexp} {σ : State}
-      (h : denB b1 σ (some false)) : denB (.and b1 b2) σ (some false)
+      (h : denB b1 σ (.val false)) : denB (.and b1 b2) σ (.val false)
   /-- `[[B1 && B2]]` — continue to b2 when b1 is true. -/
   | and_true {b1 b2 : Bexp} {σ : State} {v : Bool}
-      (h1 : denB b1 σ (some true)) (h2 : denB b2 σ (some v)) :
-      denB (.and b1 b2) σ (some v)
+      (h1 : denB b1 σ (.val true)) (h2 : denB b2 σ (.val v)) :
+      denB (.and b1 b2) σ (.val v)
   /-- `[[B1 && B2]]` — first operand `Error`. -/
   | and_err_l {b1 b2 : Bexp} {σ : State}
-      (h : denB b1 σ none) : denB (.and b1 b2) σ none
+      (h : denB b1 σ .error) : denB (.and b1 b2) σ .error
   /-- `[[B1 && B2]]` — second operand `Error` (only when b1 is true). -/
   | and_err_r {b1 b2 : Bexp} {σ : State}
-      (h1 : denB b1 σ (some true)) (h2 : denB b2 σ none) :
-      denB (.and b1 b2) σ none
+      (h1 : denB b1 σ (.val true)) (h2 : denB b2 σ .error) :
+      denB (.and b1 b2) σ .error
+  /-- `[[B1 && B2]]` — first operand is ordinary `undefined`. -/
+  | and_undef_l {b1 b2 : Bexp} {σ : State}
+      (h : denB b1 σ .undef) : denB (.and b1 b2) σ .undef
+  /-- `[[B1 && B2]]` — second operand is ordinary `undefined`. -/
+  | and_undef_r {b1 b2 : Bexp} {σ : State}
+      (h1 : denB b1 σ (.val true)) (h2 : denB b2 σ .undef) :
+      denB (.and b1 b2) σ .undef
 
 /-! ## Statement denotation — with silent failure (Ex. 83) -/
 
@@ -109,12 +181,12 @@ inductive denS : Stmt → State → State → Prop
   /-- `[[X = A ;]]` — normal. Requires X to be declared, just like Maude's
   `_`(_`)(σ, X) =/=Bool undefined` guard. -/
   | assign_ok {σ : State} {X : Id} {a : Aexp} {n : Int}
-      (hDecl : σ X ≠ none) (hA : denA a σ (some n)) :
+      (hDecl : σ X ≠ none) (hA : denA a σ (.val n)) :
       denS (.assign X a) σ (σ.update X n)
   /-- **Silent-failure assignment** — Maude: if `[[A]](σ) == Error` then
-  commit to `σ & err |-> 1`. Every such Stmt has an output state. -/
+  commit to `σ & err |-> 1`. Ordinary `undefined` still stays bottom. -/
   | assign_err {σ : State} {X : Id} {a : Aexp}
-      (hA : denA a σ none) :
+      (hA : denA a σ .error) :
       denS (.assign X a) σ σ.markFailed
   /-- `[[S1 S2]]` — S1 fails silently, skip S2. Maude: `ifCPO(
   _`(_`)(appCPO([[S1]],σ), err) ==Bool undefined, ..., appCPO([[S1]],σ))`. -/
@@ -127,31 +199,31 @@ inductive denS : Stmt → State → State → Prop
       denS (.seq s1 s2) σ σ''
   /-- `[[if (B) S1 else S2]]` — guard true. -/
   | ite_true {b : Bexp} {s1 s2 : Stmt} {σ σ' : State}
-      (hb : denB b σ (some true)) (h : denS s1 σ σ') :
+      (hb : denB b σ (.val true)) (h : denS s1 σ σ') :
       denS (.ite b s1 s2) σ σ'
   /-- `[[if (B) S1 else S2]]` — guard false. -/
   | ite_false {b : Bexp} {s1 s2 : Stmt} {σ σ' : State}
-      (hb : denB b σ (some false)) (h : denS s2 σ σ') :
+      (hb : denB b σ (.val false)) (h : denS s2 σ σ') :
       denS (.ite b s1 s2) σ σ'
   /-- **Silent-failure if** — guard errors ⇒ silently fail. Maude:
   `ifCPO(appCPO([[B]],σ) ==Bool Error, σ & err |-> 1, ...)`. -/
   | ite_err {b : Bexp} {s1 s2 : Stmt} {σ : State}
-      (hb : denB b σ none) : denS (.ite b s1 s2) σ σ.markFailed
+      (hb : denB b σ .error) : denS (.ite b s1 s2) σ σ.markFailed
   /-- `[[while (B) S]]` — guard false ⇒ terminate. -/
   | while_false {b : Bexp} {s : Stmt} {σ : State}
-      (hb : denB b σ (some false)) : denS (.while b s) σ σ
+      (hb : denB b σ (.val false)) : denS (.while b s) σ σ
   /-- `[[while (B) S]]` — guard true, body fails silently ⇒ absorb failure. -/
   | while_body_failed {b : Bexp} {s : Stmt} {σ σ' : State}
-      (hb : denB b σ (some true)) (h : denS s σ σ') (hFail : σ'.isFailed) :
+      (hb : denB b σ (.val true)) (h : denS s σ σ') (hFail : σ'.isFailed) :
       denS (.while b s) σ σ'
   /-- `[[while (B) S]]` — guard true, body ok, continue. -/
   | while_true {b : Bexp} {s : Stmt} {σ σ' σ'' : State}
-      (hb : denB b σ (some true)) (h : denS s σ σ') (hOk : ¬ σ'.isFailed)
+      (hb : denB b σ (.val true)) (h : denS s σ σ') (hOk : ¬ σ'.isFailed)
       (hLoop : denS (.while b s) σ' σ'') :
       denS (.while b s) σ σ''
   /-- **Silent-failure while-guard** — guard errors ⇒ fail silently. -/
   | while_err {b : Bexp} {s : Stmt} {σ : State}
-      (hb : denB b σ none) : denS (.while b s) σ σ.markFailed
+      (hb : denB b σ .error) : denS (.while b s) σ σ.markFailed
 
 /-! ## Program denotation -/
 
@@ -165,12 +237,18 @@ inductive denP : Pgm → State → Prop
 section Smoke
 
 /-- `[[1/0]](∅) = Error` — Maude `red appCPO([[1 / 0]], .State) .`. -/
-example : denA (.div (.const 1) (.const 0)) State.empty none :=
+example : denA (.div (.const 1) (.const 0)) State.empty .error :=
   denA.div_zero (denA.const 0 _)
 
-/-- `[[6/2]](∅) = some 3`. -/
-example : denA (.div (.const 6) (.const 2)) State.empty (some 3) :=
+/-- `[[6/2]](∅) = 3`. -/
+example : denA (.div (.const 6) (.const 2)) State.empty (.val 3) :=
   denA.div_ok (denA.const 6 _) (denA.const 2 _) (by decide)
+
+/-- `[[y]](x|->2) = undefined`, not Ex. 83 `Error`. -/
+example : denA (.var "y") ((State.empty).update "x" 2) .undef := by
+  apply denA.var_undef
+  unfold State.update State.empty
+  simp
 
 /-- `[[x = 3/0 ;]](x|->2) = markFailed (x|->2)` — silent failure. -/
 example : denS (.assign "x" (.div (.const 3) (.const 0)))

--- a/Imp/HW2/README.md
+++ b/Imp/HW2/README.md
@@ -1,0 +1,41 @@
+# CS522 HW2 in Lean 4
+
+Lean 4 port of CS522 Homework 2, **Exercise 83** — denotational semantics
+of IMP with silent division-by-zero failure.
+
+(Exercises 80, 81, 82 are paper/PDF proofs; out of scope here.)
+
+## File map
+
+| File                         | Maps to (Maude)                                                                                         |
+|------------------------------|---------------------------------------------------------------------------------------------------------|
+| `Imp/HW2/Syntax.lean`        | `HW2-Maude/imp/0-imp-original/imp-syntax.maude` + `state.maude` + the HW's reserved `op err : -> Id .` |
+| `Imp/HW2/Denotational.lean`  | `HW2-Maude/imp/0-imp-original/4-imp-denotational/imp-semantics-denotational.maude` (Ex. 83)            |
+| `Imp/HW2.lean`               | aggregate                                                                                               |
+
+## Design summary
+
+* `denA : Aexp → State → Option Int → Prop` — `some n` = value, `none` =
+  Maude's `Error` at AExp level.
+* `denB : Bexp → State → Option Bool → Prop` — similarly.
+* `denS : Stmt → State → State → Prop` — **total** at the Stmt level: every
+  Stmt has an output state. Division-by-zero in an assignment, if-guard, or
+  while-guard produces `State.markFailed σ` (i.e. `σ & err |-> 1` with
+  `errId := "__err__"`).
+* `denS.seq_failed` / `denS.seq_ok` short-circuit the sequencing equation:
+  if `s1` returned a failed state, skip `s2`; otherwise continue.
+* `denS.while_true` / `.while_body_failed` / `.while_err` implement the
+  unfolded fixpoint equation with silent-failure absorption.
+* No CPO / `fixCPO` machinery is reproduced here; instead, non-termination
+  of `while` corresponds to the absence of a `denS` derivation (same
+  convention as `Imp/main.lean`'s `terminate`).
+
+## Verification status
+
+* `lake build` passes.
+* Smoke examples at the bottom of `Denotational.lean`: `[[1/0]] = Error`,
+  `[[6/2]] = 3`, `[[x = 3/0 ;]](x|->2) = markFailed (x|->2)`.
+* Paper exercises 80/81/82 are not formalized (per HW spec, they are PDF-
+  submission proofs). Future work in this repo could add them.
+* Independent verification is requested from Stepan Nesterov per
+  `experiments/02_do_all_cs522_in_Lean/prompt.md`.

--- a/Imp/HW2/README.md
+++ b/Imp/HW2/README.md
@@ -15,26 +15,27 @@ of IMP with silent division-by-zero failure.
 
 ## Design summary
 
-* `denA : Aexp → State → Option Int → Prop` — `some n` = value, `none` =
-  Maude's `Error` at AExp level.
-* `denB : Bexp → State → Option Bool → Prop` — similarly.
-* `denS : Stmt → State → State → Prop` — **total** at the Stmt level: every
-  Stmt has an output state. Division-by-zero in an assignment, if-guard, or
+* `denA : Aexp → State → AResult → Prop` — arithmetic results are either a
+  value, Ex. 83 `Error`, or ordinary `undefined`.
+* `denB : Bexp → State → BResult → Prop` — similarly.
+* `denS : Stmt → State → State → Prop` — statement-level silent failure only
+  fires on Ex. 83 `Error`. Division-by-zero in an assignment, if-guard, or
   while-guard produces `State.markFailed σ` (i.e. `σ & err |-> 1` with
-  `errId := "__err__"`).
+  `errId := "__err__"`), while plain `undefined` still has no derivation.
 * `denS.seq_failed` / `denS.seq_ok` short-circuit the sequencing equation:
   if `s1` returned a failed state, skip `s2`; otherwise continue.
 * `denS.while_true` / `.while_body_failed` / `.while_err` implement the
   unfolded fixpoint equation with silent-failure absorption.
 * No CPO / `fixCPO` machinery is reproduced here; instead, non-termination
-  of `while` corresponds to the absence of a `denS` derivation (same
-  convention as `Imp/main.lean`'s `terminate`).
+  and ordinary bottom cases correspond to the absence of a `denS`
+  derivation (same convention as `Imp/main.lean`'s `terminate`).
 
 ## Verification status
 
 * `lake build` passes.
 * Smoke examples at the bottom of `Denotational.lean`: `[[1/0]] = Error`,
-  `[[6/2]] = 3`, `[[x = 3/0 ;]](x|->2) = markFailed (x|->2)`.
+  `[[6/2]] = 3`, `[[y]](x|->2) = undefined`, and
+  `[[x = 3/0 ;]](x|->2) = markFailed (x|->2)`.
 * Paper exercises 80/81/82 are not formalized (per HW spec, they are PDF-
   submission proofs). Future work in this repo could add them.
 * Independent verification is requested from Stepan Nesterov per

--- a/Imp/HW2/Syntax.lean
+++ b/Imp/HW2/Syntax.lean
@@ -7,8 +7,9 @@ silent division-by-zero failure). Mirrors
 
 Note: unlike HW1's small-step port we do **not** need the syntactic
 `errorAr / errorBool / errorStmt` constructors — the HW2 denotational
-solution expresses errors via the *value* domain and a reserved `err`
-flag in `State`, not via syntax. See `Imp/HW2/Denotational.lean`.
+solution expresses Ex. 83's `Error` and the pre-existing `undefined`
+bottom via *result* domains, plus a reserved `err` flag in `State`, not
+via syntax. See `Imp/HW2/Denotational.lean`.
 -/
 
 namespace Imp.HW2

--- a/Imp/HW2/Syntax.lean
+++ b/Imp/HW2/Syntax.lean
@@ -1,0 +1,96 @@
+/-!
+# CS522 HW2 — IMP syntax (denotational track)
+
+Lean 4 AST for CS522 Homework 2, Exercise 83 (denotational semantics with
+silent division-by-zero failure). Mirrors
+`brando90/cs522:HW2-Maude/imp/0-imp-original/imp-syntax.maude`.
+
+Note: unlike HW1's small-step port we do **not** need the syntactic
+`errorAr / errorBool / errorStmt` constructors — the HW2 denotational
+solution expresses errors via the *value* domain and a reserved `err`
+flag in `State`, not via syntax. See `Imp/HW2/Denotational.lean`.
+-/
+
+namespace Imp.HW2
+
+/-- Program variable names. -/
+abbrev Id := String
+
+/-- Arithmetic expressions — Maude `AExp`. -/
+inductive Aexp where
+  | const : Int → Aexp
+  | var   : Id  → Aexp
+  | add   : Aexp → Aexp → Aexp
+  | div   : Aexp → Aexp → Aexp
+deriving Repr, DecidableEq
+
+/-- Boolean expressions — Maude `BExp`. -/
+inductive Bexp where
+  | b   : Bool → Bexp
+  | le  : Aexp → Aexp → Bexp
+  | not : Bexp → Bexp
+  | and : Bexp → Bexp → Bexp
+deriving Repr, DecidableEq
+
+/-- Statements — Maude `Stmt`. `skip` plays the role of the empty block `{}`. -/
+inductive Stmt where
+  | skip   : Stmt
+  | assign : Id → Aexp → Stmt
+  | seq    : Stmt → Stmt → Stmt
+  | ite    : Bexp → Stmt → Stmt → Stmt
+  | while  : Bexp → Stmt → Stmt
+deriving Repr, DecidableEq
+
+/-- A complete IMP program — Maude `int Xl ; S`. -/
+structure Pgm where
+  vars : List Id
+  body : Stmt
+deriving Repr
+
+/-- Program state: partial map from variable names to integers.
+`none` = undefined binding. -/
+abbrev State := Id → Option Int
+
+namespace State
+
+/-- Empty state — no variables bound. -/
+def empty : State := fun _ => none
+
+/-- Point-wise update `σ[n/X]`. -/
+def update (σ : State) (X : Id) (n : Int) : State :=
+  fun Y => if Y = X then some n else σ Y
+
+/-- Initialise a list of variables all to 0 (matches Maude `Xl |-> 0`). -/
+def initZero : List Id → State
+  | []      => empty
+  | X :: Xs => (initZero Xs).update X 0
+
+end State
+
+/-! ## The silent-failure "err" flag
+
+The HW2 Maude solution introduces a reserved `op err : -> Id .` that is
+never declared by the user and is used in the denotational equations as a
+"silent-failure" flag: when a Stmt would otherwise diverge on an
+arithmetic `Error`, the equation instead commits to `sigma & err |-> 1`.
+
+In Lean, since `Id` is just `String`, we pick a reserved string that user
+programs are expected not to use. The test battery in `my_test.maude`
+matches `red appCPO([[err]], x |-> 3 & err |-> 1)` against our `"__err__"`. -/
+
+/-- Reserved identifier used as a silent-failure flag in the HW2 denotation. -/
+def errId : Id := "__err__"
+
+/-- A state has *silently failed* if the reserved `err` identifier is bound
+to `1`. -/
+def State.isFailed (σ : State) : Prop := σ errId = some 1
+
+/-- Mark a state as silently failed — the Maude move `sigma & err |-> 1`. -/
+def State.markFailed (σ : State) : State := σ.update errId 1
+
+@[simp] theorem State.markFailed_isFailed (σ : State) :
+    (σ.markFailed).isFailed := by
+  unfold State.isFailed State.markFailed State.update
+  simp [errId]
+
+end Imp.HW2


### PR DESCRIPTION
## Summary

- Ports CS522 HW2 **Exercise 83** (denotational semantics with silent division-by-zero failure) from Maude to Lean 4.
- `Imp/HW2/Syntax.lean` — AST + `State` + reserved `errId = "__err__"` flag with `State.isFailed / State.markFailed`.
- `Imp/HW2/Denotational.lean` — relational denotation `denA / denB / denS / denP`; `denS` is total, silent-failure committed via `markFailed`.
- `Imp/HW2/README.md` — Lean-to-Maude file mapping + design rationale.

Maude-side context is in `brando90/cs522@master` commit [`ca03448`](https://github.com/brando90/cs522/commit/ca03448) — docstring pass on `imp-semantics-denotational.maude`.

**Out of scope (per HW spec):** Exercises 80, 81, 82 are paper/PDF proofs about while-loop equivalences, `w_k` well-definedness, and fixed-point characterization of the while-functional. Not formalized here.

## Test plan

- [x] `lake build` completes successfully (3111 jobs).
- [x] Smoke examples in `Denotational.lean`: `[[1/0]] = none (Error)`, `[[6/2]] = some 3`, `[[x = 3/0 ;]](x|->2) = markFailed (x|->2)`.
- [ ] Behavioural verification against `my_test.maude`: not run (no local maude).
- [ ] Independent review from **Stepan Nesterov** (`stepurik@stanford.edu`) — email will follow after merge.

## Mega QA plan

3-stage sequential chain (CC → Codex → Gemini) per `~/agents-config/INDEX_RULES.md` Rule 10. Results posted as PR comments.