### PR TITLE
HW3a (CS522): Lean port of IMP++ syntax + big-step SOS

### DIFF
--- a/Imp.lean
+++ b/Imp.lean
@@ -1,3 +1,4 @@
 import Imp.main
 import Imp.HW1
 import Imp.HW2
+import Imp.HW3

--- a/Imp/HW3.lean
+++ b/Imp/HW3.lean
@@ -1,0 +1,17 @@
+import Imp.HW3.Syntax
+import Imp.HW3.BigStep
+
+/-!
+# CS522 HW3a — IMP++ aggregate (big-step only)
+
+This is the first of a sequence of HW3 PRs:
+
+* **HW3a (this PR):** IMP++ syntax + big-step SOS
+* HW3b (follow-up): IMP++ small-step SOS  — faithful `spawn` concurrency
+* HW3c (follow-up): IMP++ denotational semantics  (above-spec bonus)
+* HW3d (follow-up): IMP++ type-system (big-step)
+
+Maude source: `brando90/cs522:HW3/6-imp++/` (commit `3d835de` for the
+course-side README + layout; rule logic mirrors
+`6-imp++/big_step/imp-semantics-bigstep.maude`).
+-/

--- a/Imp/HW3/BigStep.lean
+++ b/Imp/HW3/BigStep.lean
@@ -1,0 +1,281 @@
+import Imp.HW3.Syntax
+
+/-!
+# CS522 HW3a — IMP++ big-step semantics
+
+Faithful Lean 4 port of the big-step SOS in
+`brando90/cs522:HW3/6-imp++/big_step/imp-semantics-bigstep.maude`.
+
+## Configurations
+
+The Maude configurations carry `(syntax, State, Buffer)` at entry and
+`(State, Buffer_in, Buffer_out)` or `(error, State, Buffer)` or
+`(halting, State, Buffer_in, Buffer_out)` at exit. In Lean we split the
+result into an `SResult` sum:
+
+- `state σ inB outB`        — normal termination with updated buffers
+- `err   σ inB`             — error result (from div-by-zero inside a Stmt)
+- `halted σ inB outB`       — the `halt;` statement was executed
+
+and similarly for AExp / BExp (which in Maude return just `(Int, State, Buf)`
+or `(error, State, Buf)` — we use `AResult` / `BResult`).
+
+## Simplifications / honest deviations from Maude
+
+1. **`spawn { S }` is modelled sequentially** at big-step level — we
+   just reduce the spawned block as if it were an inlined sub-statement.
+   This is the standard big-step treatment; truly concurrent semantics
+   require small-step and will land in the HW3b follow-up PR.
+
+2. **Local variable declarations** (`int xl ;`) update the state in place
+   with zero-initialised bindings. We *do not* implement lexical scoping
+   restoration here; that is easier to model in small-step where block
+   entry/exit are explicit points in the reduction.
+
+3. **Error propagation** follows Maude: an arithmetic `error` inside a
+   Stmt produces an `SResult.err` which the SEQ rule short-circuits on.
+
+4. **Halting propagation**: once the `halt;` statement fires, it produces
+   an `SResult.halted` which subsequent Stmts (via SEQ) absorb without
+   further effect, matching the Maude `halting` configuration.
+-/
+
+namespace Imp.HW3
+
+/-! ## Result domains -/
+
+/-- Big-step result for an arithmetic expression. -/
+inductive AResult where
+  | num (n : Int) (σ : State) (inB : Buffer) : AResult
+  | err           (σ : State) (inB : Buffer) : AResult
+
+/-- Big-step result for a boolean expression. -/
+inductive BResult where
+  | bool (v : Bool) (σ : State) (inB : Buffer) : BResult
+  | err            (σ : State) (inB : Buffer) : BResult
+
+/-- Big-step result for a statement. -/
+inductive SResult where
+  /-- Normal termination. -/
+  | state  : State → Buffer → Buffer → SResult
+  /-- Arithmetic error has propagated up to Stmt level. -/
+  | err    : State → Buffer → SResult
+  /-- The `halt;` statement was reached. Halting freezes the state and
+  both buffers. -/
+  | halted : State → Buffer → Buffer → SResult
+
+/-! ## Arithmetic-expression big-step (`< A, σ, inB > ⇓ < v >`)
+
+Maude rule names retained in constructor names where practical. -/
+
+inductive evalA : Aexp → State → Buffer → AResult → Prop
+  /-- Integer literal. -/
+  | const (n : Int) (σ : State) (inB : Buffer) :
+      evalA (.const n) σ inB (.num n σ inB)
+  /-- Defined variable lookup. -/
+  | var_ok {σ : State} {inB : Buffer} {X : Id} {n : Int}
+      (h : σ X = some n) : evalA (.var X) σ inB (.num n σ inB)
+  /-- `read()` consumes the head of the input buffer. -/
+  | read_ok {σ : State} {n : Int} {inB' : Buffer} :
+      evalA .read σ (n :: inB') (.num n σ inB')
+  /-- `read()` on an empty input buffer is stuck — we model it as `err`.
+  (Maude does not specify; this is a modelling choice flagged in the README.) -/
+  | read_err {σ : State} : evalA .read σ [] (.err σ [])
+  /-- Addition — normal. -/
+  | add {a1 a2 : Aexp} {σ σ1 σ2 : State} {inB inB1 inB2 : Buffer} {n1 n2 : Int}
+      (h1 : evalA a1 σ inB (.num n1 σ1 inB1))
+      (h2 : evalA a2 σ1 inB1 (.num n2 σ2 inB2)) :
+      evalA (.add a1 a2) σ inB (.num (n1 + n2) σ2 inB2)
+  /-- Addition — left errors. -/
+  | add_err_l {a1 a2 : Aexp} {σ σ1 : State} {inB inB1 : Buffer}
+      (h : evalA a1 σ inB (.err σ1 inB1)) :
+      evalA (.add a1 a2) σ inB (.err σ1 inB1)
+  /-- Addition — right errors (after left is a value). -/
+  | add_err_r {a1 a2 : Aexp} {σ σ1 σ2 : State} {inB inB1 inB2 : Buffer} {n1 : Int}
+      (h1 : evalA a1 σ inB (.num n1 σ1 inB1))
+      (h2 : evalA a2 σ1 inB1 (.err σ2 inB2)) :
+      evalA (.add a1 a2) σ inB (.err σ2 inB2)
+  /-- Division — normal. -/
+  | div_ok {a1 a2 : Aexp} {σ σ1 σ2 : State} {inB inB1 inB2 : Buffer} {n1 n2 : Int}
+      (h1 : evalA a1 σ inB (.num n1 σ1 inB1))
+      (h2 : evalA a2 σ1 inB1 (.num n2 σ2 inB2)) (hne : n2 ≠ 0) :
+      evalA (.div a1 a2) σ inB (.num (n1 / n2) σ2 inB2)
+  /-- Division — divisor evaluates to 0. -/
+  | div_by_zero {a1 a2 : Aexp} {σ σ1 σ2 : State} {inB inB1 inB2 : Buffer} {n1 : Int}
+      (h1 : evalA a1 σ inB (.num n1 σ1 inB1))
+      (h2 : evalA a2 σ1 inB1 (.num 0 σ2 inB2)) :
+      evalA (.div a1 a2) σ inB (.err σ2 inB2)
+  /-- Division — left operand errors. -/
+  | div_err_l {a1 a2 : Aexp} {σ σ1 : State} {inB inB1 : Buffer}
+      (h : evalA a1 σ inB (.err σ1 inB1)) :
+      evalA (.div a1 a2) σ inB (.err σ1 inB1)
+  /-- Division — right operand errors. -/
+  | div_err_r {a1 a2 : Aexp} {σ σ1 σ2 : State} {inB inB1 inB2 : Buffer} {n1 : Int}
+      (h1 : evalA a1 σ inB (.num n1 σ1 inB1))
+      (h2 : evalA a2 σ1 inB1 (.err σ2 inB2)) :
+      evalA (.div a1 a2) σ inB (.err σ2 inB2)
+
+/-! ## Boolean-expression big-step -/
+
+inductive evalB : Bexp → State → Buffer → BResult → Prop
+  | b (v : Bool) (σ : State) (inB : Buffer) : evalB (.b v) σ inB (.bool v σ inB)
+  /-- `A1 <= A2` normal. -/
+  | le {a1 a2 : Aexp} {σ σ1 σ2 : State} {inB inB1 inB2 : Buffer} {n1 n2 : Int}
+      (h1 : evalA a1 σ inB (.num n1 σ1 inB1))
+      (h2 : evalA a2 σ1 inB1 (.num n2 σ2 inB2)) :
+      evalB (.le a1 a2) σ inB (.bool (decide (n1 ≤ n2)) σ2 inB2)
+  /-- `A1 <= A2` left errors. -/
+  | le_err_l {a1 a2 : Aexp} {σ σ1 : State} {inB inB1 : Buffer}
+      (h : evalA a1 σ inB (.err σ1 inB1)) :
+      evalB (.le a1 a2) σ inB (.err σ1 inB1)
+  /-- `A1 <= A2` right errors. -/
+  | le_err_r {a1 a2 : Aexp} {σ σ1 σ2 : State} {inB inB1 inB2 : Buffer} {n1 : Int}
+      (h1 : evalA a1 σ inB (.num n1 σ1 inB1))
+      (h2 : evalA a2 σ1 inB1 (.err σ2 inB2)) :
+      evalB (.le a1 a2) σ inB (.err σ2 inB2)
+  /-- `!true` / `!false`. -/
+  | not_t {b : Bexp} {σ σ' : State} {inB inB' : Buffer}
+      (h : evalB b σ inB (.bool true σ' inB')) :
+      evalB (.not b) σ inB (.bool false σ' inB')
+  | not_f {b : Bexp} {σ σ' : State} {inB inB' : Buffer}
+      (h : evalB b σ inB (.bool false σ' inB')) :
+      evalB (.not b) σ inB (.bool true σ' inB')
+  | not_err {b : Bexp} {σ σ' : State} {inB inB' : Buffer}
+      (h : evalB b σ inB (.err σ' inB')) :
+      evalB (.not b) σ inB (.err σ' inB')
+  /-- `B1 && B2`. -/
+  | and_false {b1 b2 : Bexp} {σ σ1 : State} {inB inB1 : Buffer}
+      (h : evalB b1 σ inB (.bool false σ1 inB1)) :
+      evalB (.and b1 b2) σ inB (.bool false σ1 inB1)
+  | and_true {b1 b2 : Bexp} {σ σ1 σ2 : State} {inB inB1 inB2 : Buffer} {v : Bool}
+      (h1 : evalB b1 σ inB (.bool true σ1 inB1))
+      (h2 : evalB b2 σ1 inB1 (.bool v σ2 inB2)) :
+      evalB (.and b1 b2) σ inB (.bool v σ2 inB2)
+  | and_err_l {b1 b2 : Bexp} {σ σ1 : State} {inB inB1 : Buffer}
+      (h : evalB b1 σ inB (.err σ1 inB1)) :
+      evalB (.and b1 b2) σ inB (.err σ1 inB1)
+
+/-! ## Statement big-step
+
+`evalS s σ inB outB r` ≅ Maude `< s, σ, inB, outB > ⇓ r`. We add `outB` as
+an input to `evalS` because statements can both read *and* write buffers
+(via nested `read()` expressions and `print(a);` statements respectively). -/
+
+inductive evalS : Stmt → State → Buffer → Buffer → SResult → Prop
+  /-- `skip` — no-op. -/
+  | skip (σ : State) (inB outB : Buffer) :
+      evalS .skip σ inB outB (.state σ inB outB)
+  /-- `X = A ;` normal case (Maude: `Sigma(X) =/=Bool undefined`). -/
+  | assign_ok {σ σ' : State} {inB inB' outB : Buffer} {X : Id} {a : Aexp} {n : Int}
+      (hDecl : σ X ≠ none) (hA : evalA a σ inB (.num n σ' inB')) :
+      evalS (.assign X a) σ inB outB (.state (σ'.update X n) inB' outB)
+  /-- `X = A ;` — RHS errors. -/
+  | assign_err {σ σ' : State} {inB inB' outB : Buffer} {X : Id} {a : Aexp}
+      (hA : evalA a σ inB (.err σ' inB')) :
+      evalS (.assign X a) σ inB outB (.err σ' inB')
+  /-- `S1 S2` — normal case. -/
+  | seq_ok {s1 s2 : Stmt} {σ σ' : State} {inB inB' outB outB' : Buffer} {r : SResult}
+      (h1 : evalS s1 σ inB outB (.state σ' inB' outB'))
+      (h2 : evalS s2 σ' inB' outB' r) :
+      evalS (.seq s1 s2) σ inB outB r
+  /-- `S1 S2` — first statement errors; skip S2. -/
+  | seq_err_l {s1 s2 : Stmt} {σ σ' : State} {inB inB' outB : Buffer}
+      (h : evalS s1 σ inB outB (.err σ' inB')) :
+      evalS (.seq s1 s2) σ inB outB (.err σ' inB')
+  /-- `S1 S2` — first statement halts; skip S2 (halt absorbs). -/
+  | seq_halted_l {s1 s2 : Stmt} {σ σ' : State} {inB inB' outB outB' : Buffer}
+      (h : evalS s1 σ inB outB (.halted σ' inB' outB')) :
+      evalS (.seq s1 s2) σ inB outB (.halted σ' inB' outB')
+  /-- `if (B) S1 else S2` — guard true. -/
+  | ite_true {b : Bexp} {s1 s2 : Stmt} {σ σ' : State} {inB inB' outB : Buffer} {r : SResult}
+      (hb : evalB b σ inB (.bool true σ' inB')) (h : evalS s1 σ' inB' outB r) :
+      evalS (.ite b s1 s2) σ inB outB r
+  /-- `if (B) S1 else S2` — guard false. -/
+  | ite_false {b : Bexp} {s1 s2 : Stmt} {σ σ' : State} {inB inB' outB : Buffer} {r : SResult}
+      (hb : evalB b σ inB (.bool false σ' inB')) (h : evalS s2 σ' inB' outB r) :
+      evalS (.ite b s1 s2) σ inB outB r
+  /-- `if (B) …` — guard errors. -/
+  | ite_err {b : Bexp} {s1 s2 : Stmt} {σ σ' : State} {inB inB' outB : Buffer}
+      (hb : evalB b σ inB (.err σ' inB')) :
+      evalS (.ite b s1 s2) σ inB outB (.err σ' inB')
+  /-- `while (B) S` — guard false, loop terminates in place. -/
+  | while_false {b : Bexp} {s : Stmt} {σ σ' : State} {inB inB' outB : Buffer}
+      (hb : evalB b σ inB (.bool false σ' inB')) :
+      evalS (.while b s) σ inB outB (.state σ' inB' outB)
+  /-- `while (B) S` — guard errors. -/
+  | while_err_guard {b : Bexp} {s : Stmt} {σ σ' : State} {inB inB' outB : Buffer}
+      (hb : evalB b σ inB (.err σ' inB')) :
+      evalS (.while b s) σ inB outB (.err σ' inB')
+  /-- `while (B) S` — guard true, unroll. Matches Maude's recursive
+  `< S while (B) S, Sigma, inB, outB > => < r >`. -/
+  | while_true {b : Bexp} {s : Stmt} {σ σ' : State} {inB inB' outB : Buffer} {r : SResult}
+      (hb : evalB b σ inB (.bool true σ' inB'))
+      (h : evalS (.seq s (.while b s)) σ' inB' outB r) :
+      evalS (.while b s) σ inB outB r
+  /-- `halt;` — freezes the state and both buffers into a `halted` result. -/
+  | halt (σ : State) (inB outB : Buffer) :
+      evalS .halt σ inB outB (.halted σ inB outB)
+  /-- `print(A);` — normal. -/
+  | print_ok {σ σ' : State} {inB inB' outB : Buffer} {a : Aexp} {n : Int}
+      (hA : evalA a σ inB (.num n σ' inB')) :
+      evalS (.print a) σ inB outB (.state σ' inB' (outB.snoc n))
+  /-- `print(A);` — argument errors. -/
+  | print_err {σ σ' : State} {inB inB' outB : Buffer} {a : Aexp}
+      (hA : evalA a σ inB (.err σ' inB')) :
+      evalS (.print a) σ inB outB (.err σ' inB')
+  /-- `int xl;` — declare-and-zero-initialise each variable. Matches the
+  Maude desugaring that turns `int xl` into repeated `let X = 0 in ...`. -/
+  | intDecl (σ : State) (inB outB : Buffer) (xl : List Id) :
+      evalS (.intDecl xl) σ inB outB (.state (State.initZero xl σ) inB outB)
+  /-- `let X = A in S` — bind X, run S (possibly shadowing / overwriting X).
+  We do NOT restore X on exit at big-step level — small-step is the better
+  place to express that, flagged in the file docstring. -/
+  | letIn_ok {σ σA σ' : State} {inB inB' inB'' outB outB' : Buffer}
+             {X : Id} {a : Aexp} {n : Int} {s : Stmt} {r : SResult}
+      (hA : evalA a σ inB (.num n σA inB'))
+      (h : evalS s (σA.update X n) inB' outB r) : evalS (.letIn X a s) σ inB outB r
+  /-- `let X = A in S` — binding-RHS errors. -/
+  | letIn_err {σ σ' : State} {inB inB' outB : Buffer} {X : Id} {a : Aexp} {s : Stmt}
+      (hA : evalA a σ inB (.err σ' inB')) :
+      evalS (.letIn X a s) σ inB outB (.err σ' inB')
+  /-- `spawn { S }` — executed sequentially in the big-step port (see
+  file docstring §"Simplifications"). -/
+  | spawn {σ : State} {inB outB : Buffer} {s : Stmt} {r : SResult}
+      (h : evalS s σ inB outB r) : evalS (.spawn s) σ inB outB r
+
+/-! ## Program-level
+
+Per Maude `subsort Stmt < Pgm`, an IMP++ program is just a top-level Stmt. -/
+
+/-- Execute an IMP++ program on an input buffer; produce an `SResult`. -/
+inductive evalP : Pgm → Buffer → SResult → Prop
+  | run {p : Pgm} {inB : Buffer} {r : SResult}
+      (h : evalS p State.empty inB Buffer.empty r) : evalP p inB r
+
+/-! ## Smoke tests — small IMP++ programs -/
+
+section Smoke
+
+/-- `halt;` produces a `halted` result with empty state + buffers. -/
+example : evalS .halt State.empty [] []
+            (.halted State.empty [] []) :=
+  evalS.halt _ _ _
+
+/-- `print(1);` on the empty initial config appends `1` to the output buffer. -/
+example :
+    evalS (.print (.const 1)) State.empty [] []
+      (.state State.empty [] [1]) := by
+  have := evalS.print_ok (σ := State.empty) (σ' := State.empty)
+            (inB := []) (inB' := []) (outB := [])
+            (a := .const 1) (n := 1)
+            (hA := evalA.const 1 State.empty [])
+  simpa [Buffer.snoc] using this
+
+/-- `read()` consumes the head of the input buffer. -/
+example :
+    evalA .read State.empty [42, 17] (.num 42 State.empty [17]) :=
+  evalA.read_ok
+
+end Smoke
+
+end Imp.HW3

--- a/Imp/HW3/BigStep.lean
+++ b/Imp/HW3/BigStep.lean
@@ -13,8 +13,8 @@ The Maude configurations carry `(syntax, State, Buffer)` at entry and
 `(halting, State, Buffer_in, Buffer_out)` at exit. In Lean we split the
 result into an `SResult` sum:
 
-- `state σ inB outB`        — normal termination with updated buffers
-- `err   σ inB`             — error result (from div-by-zero inside a Stmt)
+- `state  σ inB outB`       — normal termination with updated buffers
+- `err    σ inB outB`       — statement-level error with buffers frozen in place
 - `halted σ inB outB`       — the `halt;` statement was executed
 
 and similarly for AExp / BExp (which in Maude return just `(Int, State, Buf)`
@@ -32,8 +32,9 @@ or `(error, State, Buf)` — we use `AResult` / `BResult`).
    restoration here; that is easier to model in small-step where block
    entry/exit are explicit points in the reduction.
 
-3. **Error propagation** follows Maude: an arithmetic `error` inside a
-   Stmt produces an `SResult.err` which the SEQ rule short-circuits on.
+3. **Statement-level errors** are kept distinct from `halt;`, but they now
+   freeze both buffers just like other statement results so prior output is
+   not lost during propagation through `SEQ`, `if`, `while`, `print`, or `let`.
 
 4. **Halting propagation**: once the `halt;` statement fires, it produces
    an `SResult.halted` which subsequent Stmts (via SEQ) absorb without
@@ -58,8 +59,9 @@ inductive BResult where
 inductive SResult where
   /-- Normal termination. -/
   | state  : State → Buffer → Buffer → SResult
-  /-- Arithmetic error has propagated up to Stmt level. -/
-  | err    : State → Buffer → SResult
+  /-- Arithmetic / guard error has propagated up to Stmt level; the current
+  state and both buffers are frozen. -/
+  | err    : State → Buffer → Buffer → SResult
   /-- The `halt;` statement was reached. Halting freezes the state and
   both buffers. -/
   | halted : State → Buffer → Buffer → SResult
@@ -81,10 +83,11 @@ inductive evalA : Aexp → State → Buffer → AResult → Prop
   /-- `read()` on an empty input buffer is stuck — we model it as `err`.
   (Maude does not specify; this is a modelling choice flagged in the README.) -/
   | read_err {σ : State} : evalA .read σ [] (.err σ [])
-  /-- Addition — normal. -/
+  /-- Addition — Maude's left-to-right normal rule, including the source
+  side condition on the second value. -/
   | add {a1 a2 : Aexp} {σ σ1 σ2 : State} {inB inB1 inB2 : Buffer} {n1 n2 : Int}
       (h1 : evalA a1 σ inB (.num n1 σ1 inB1))
-      (h2 : evalA a2 σ1 inB1 (.num n2 σ2 inB2)) :
+      (h2 : evalA a2 σ1 inB1 (.num n2 σ2 inB2)) (hne : n2 ≠ 0) :
       evalA (.add a1 a2) σ inB (.num (n1 + n2) σ2 inB2)
   /-- Addition — left errors. -/
   | add_err_l {a1 a2 : Aexp} {σ σ1 : State} {inB inB1 : Buffer}
@@ -94,6 +97,20 @@ inductive evalA : Aexp → State → Buffer → AResult → Prop
   | add_err_r {a1 a2 : Aexp} {σ σ1 σ2 : State} {inB inB1 inB2 : Buffer} {n1 : Int}
       (h1 : evalA a1 σ inB (.num n1 σ1 inB1))
       (h2 : evalA a2 σ1 inB1 (.err σ2 inB2)) :
+      evalA (.add a1 a2) σ inB (.err σ2 inB2)
+  /-- Addition — Maude's symmetric right-to-left rule. -/
+  | add_rtl {a1 a2 : Aexp} {σ σ1 σ2 : State} {inB inB1 inB2 : Buffer} {n1 n2 : Int}
+      (h2 : evalA a2 σ inB (.num n2 σ2 inB2))
+      (h1 : evalA a1 σ2 inB2 (.num n1 σ1 inB1)) :
+      evalA (.add a1 a2) σ inB (.num (n1 + n2) σ1 inB1)
+  /-- Addition — right-to-left, then left operand errors. -/
+  | add_err_l_rtl {a1 a2 : Aexp} {σ σ1 σ2 : State} {inB inB1 inB2 : Buffer} {n2 : Int}
+      (h2 : evalA a2 σ inB (.num n2 σ2 inB2))
+      (h1 : evalA a1 σ2 inB2 (.err σ1 inB1)) :
+      evalA (.add a1 a2) σ inB (.err σ1 inB1)
+  /-- Addition — right operand errors when Maude picks the right-to-left rule. -/
+  | add_err_r_rtl {a1 a2 : Aexp} {σ σ2 : State} {inB inB2 : Buffer}
+      (h2 : evalA a2 σ inB (.err σ2 inB2)) :
       evalA (.add a1 a2) σ inB (.err σ2 inB2)
   /-- Division — normal. -/
   | div_ok {a1 a2 : Aexp} {σ σ1 σ2 : State} {inB inB1 inB2 : Buffer} {n1 n2 : Int}
@@ -113,6 +130,29 @@ inductive evalA : Aexp → State → Buffer → AResult → Prop
   | div_err_r {a1 a2 : Aexp} {σ σ1 σ2 : State} {inB inB1 inB2 : Buffer} {n1 : Int}
       (h1 : evalA a1 σ inB (.num n1 σ1 inB1))
       (h2 : evalA a2 σ1 inB1 (.err σ2 inB2)) :
+      evalA (.div a1 a2) σ inB (.err σ2 inB2)
+  /-- Division — Maude's symmetric right-to-left normal rule. -/
+  | div_ok_rtl {a1 a2 : Aexp} {σ σ1 σ2 : State} {inB inB1 inB2 : Buffer} {n1 n2 : Int}
+      (h2 : evalA a2 σ inB (.num n2 σ2 inB2))
+      (h1 : evalA a1 σ2 inB2 (.num n1 σ1 inB1)) (hne : n2 ≠ 0) :
+      evalA (.div a1 a2) σ inB (.num (n1 / n2) σ1 inB1)
+  /-- Division — right-to-left, then left operand errors. -/
+  | div_err_l_rtl {a1 a2 : Aexp} {σ σ1 σ2 : State} {inB inB1 inB2 : Buffer} {n2 : Int}
+      (h2 : evalA a2 σ inB (.num n2 σ2 inB2))
+      (h1 : evalA a1 σ2 inB2 (.err σ1 inB1)) :
+      evalA (.div a1 a2) σ inB (.err σ1 inB1)
+  /-- Division — right operand errors when Maude evaluates the divisor first. -/
+  | div_err_r_rtl {a1 a2 : Aexp} {σ σ2 : State} {inB inB2 : Buffer}
+      (h2 : evalA a2 σ inB (.err σ2 inB2)) :
+      evalA (.div a1 a2) σ inB (.err σ2 inB2)
+  /-- Division by zero — right-to-left, then evaluate the numerator anyway. -/
+  | div_by_zero_rtl_after_l {a1 a2 : Aexp} {σ σ1 σ2 : State} {inB inB1 inB2 : Buffer} {n1 : Int}
+      (h2 : evalA a2 σ inB (.num 0 σ2 inB2))
+      (h1 : evalA a1 σ2 inB2 (.num n1 σ1 inB1)) :
+      evalA (.div a1 a2) σ inB (.err σ1 inB1)
+  /-- Division by zero — right-to-left immediate error. -/
+  | div_by_zero_rtl {a1 a2 : Aexp} {σ σ2 : State} {inB inB2 : Buffer}
+      (h2 : evalA a2 σ inB (.num 0 σ2 inB2)) :
       evalA (.div a1 a2) σ inB (.err σ2 inB2)
 
 /-! ## Boolean-expression big-step -/
@@ -154,6 +194,10 @@ inductive evalB : Bexp → State → Buffer → BResult → Prop
   | and_err_l {b1 b2 : Bexp} {σ σ1 : State} {inB inB1 : Buffer}
       (h : evalB b1 σ inB (.err σ1 inB1)) :
       evalB (.and b1 b2) σ inB (.err σ1 inB1)
+  | and_err_r {b1 b2 : Bexp} {σ σ1 σ2 : State} {inB inB1 inB2 : Buffer}
+      (h1 : evalB b1 σ inB (.bool true σ1 inB1))
+      (h2 : evalB b2 σ1 inB1 (.err σ2 inB2)) :
+      evalB (.and b1 b2) σ inB (.err σ2 inB2)
 
 /-! ## Statement big-step
 
@@ -171,17 +215,17 @@ inductive evalS : Stmt → State → Buffer → Buffer → SResult → Prop
       evalS (.assign X a) σ inB outB (.state (σ'.update X n) inB' outB)
   /-- `X = A ;` — RHS errors. -/
   | assign_err {σ σ' : State} {inB inB' outB : Buffer} {X : Id} {a : Aexp}
-      (hA : evalA a σ inB (.err σ' inB')) :
-      evalS (.assign X a) σ inB outB (.err σ' inB')
+      (hDecl : σ X ≠ none) (hA : evalA a σ inB (.err σ' inB')) :
+      evalS (.assign X a) σ inB outB (.err σ' inB' outB)
   /-- `S1 S2` — normal case. -/
   | seq_ok {s1 s2 : Stmt} {σ σ' : State} {inB inB' outB outB' : Buffer} {r : SResult}
       (h1 : evalS s1 σ inB outB (.state σ' inB' outB'))
       (h2 : evalS s2 σ' inB' outB' r) :
       evalS (.seq s1 s2) σ inB outB r
   /-- `S1 S2` — first statement errors; skip S2. -/
-  | seq_err_l {s1 s2 : Stmt} {σ σ' : State} {inB inB' outB : Buffer}
-      (h : evalS s1 σ inB outB (.err σ' inB')) :
-      evalS (.seq s1 s2) σ inB outB (.err σ' inB')
+  | seq_err_l {s1 s2 : Stmt} {σ σ' : State} {inB inB' outB outB' : Buffer}
+      (h : evalS s1 σ inB outB (.err σ' inB' outB')) :
+      evalS (.seq s1 s2) σ inB outB (.err σ' inB' outB')
   /-- `S1 S2` — first statement halts; skip S2 (halt absorbs). -/
   | seq_halted_l {s1 s2 : Stmt} {σ σ' : State} {inB inB' outB outB' : Buffer}
       (h : evalS s1 σ inB outB (.halted σ' inB' outB')) :
@@ -197,7 +241,7 @@ inductive evalS : Stmt → State → Buffer → Buffer → SResult → Prop
   /-- `if (B) …` — guard errors. -/
   | ite_err {b : Bexp} {s1 s2 : Stmt} {σ σ' : State} {inB inB' outB : Buffer}
       (hb : evalB b σ inB (.err σ' inB')) :
-      evalS (.ite b s1 s2) σ inB outB (.err σ' inB')
+      evalS (.ite b s1 s2) σ inB outB (.err σ' inB' outB)
   /-- `while (B) S` — guard false, loop terminates in place. -/
   | while_false {b : Bexp} {s : Stmt} {σ σ' : State} {inB inB' outB : Buffer}
       (hb : evalB b σ inB (.bool false σ' inB')) :
@@ -205,7 +249,7 @@ inductive evalS : Stmt → State → Buffer → Buffer → SResult → Prop
   /-- `while (B) S` — guard errors. -/
   | while_err_guard {b : Bexp} {s : Stmt} {σ σ' : State} {inB inB' outB : Buffer}
       (hb : evalB b σ inB (.err σ' inB')) :
-      evalS (.while b s) σ inB outB (.err σ' inB')
+      evalS (.while b s) σ inB outB (.err σ' inB' outB)
   /-- `while (B) S` — guard true, unroll. Matches Maude's recursive
   `< S while (B) S, Sigma, inB, outB > => < r >`. -/
   | while_true {b : Bexp} {s : Stmt} {σ σ' : State} {inB inB' outB : Buffer} {r : SResult}
@@ -222,7 +266,7 @@ inductive evalS : Stmt → State → Buffer → Buffer → SResult → Prop
   /-- `print(A);` — argument errors. -/
   | print_err {σ σ' : State} {inB inB' outB : Buffer} {a : Aexp}
       (hA : evalA a σ inB (.err σ' inB')) :
-      evalS (.print a) σ inB outB (.err σ' inB')
+      evalS (.print a) σ inB outB (.err σ' inB' outB)
   /-- `int xl;` — declare-and-zero-initialise each variable. Matches the
   Maude desugaring that turns `int xl` into repeated `let X = 0 in ...`. -/
   | intDecl (σ : State) (inB outB : Buffer) (xl : List Id) :
@@ -237,7 +281,7 @@ inductive evalS : Stmt → State → Buffer → Buffer → SResult → Prop
   /-- `let X = A in S` — binding-RHS errors. -/
   | letIn_err {σ σ' : State} {inB inB' outB : Buffer} {X : Id} {a : Aexp} {s : Stmt}
       (hA : evalA a σ inB (.err σ' inB')) :
-      evalS (.letIn X a s) σ inB outB (.err σ' inB')
+      evalS (.letIn X a s) σ inB outB (.err σ' inB' outB)
   /-- `spawn { S }` — executed sequentially in the big-step port (see
   file docstring §"Simplifications"). -/
   | spawn {σ : State} {inB outB : Buffer} {s : Stmt} {r : SResult}
@@ -275,6 +319,29 @@ example :
 example :
     evalA .read State.empty [42, 17] (.num 42 State.empty [17]) :=
   evalA.read_ok
+
+/-- Maude also admits right-to-left division, which matters once `read()`
+threads the input buffer. -/
+example :
+    evalA (.div .read .read) State.empty [4, 2] (.num 0 State.empty []) := by
+  exact evalA.div_ok_rtl evalA.read_ok evalA.read_ok (by decide)
+
+/-- Statement-level errors preserve output already produced by earlier
+statements in a sequence. -/
+example :
+    evalS (.seq (.print (.const 1)) (.print (.div (.const 1) (.const 0))))
+      State.empty [] []
+      (.err State.empty [] [1]) := by
+  refine evalS.seq_ok (σ' := State.empty) (inB' := []) (outB' := [1]) ?_ ?_
+  · simpa [Buffer.snoc] using
+      (evalS.print_ok (σ := State.empty) (σ' := State.empty)
+        (inB := []) (inB' := []) (outB := [])
+        (a := .const 1) (n := 1)
+        (hA := evalA.const 1 State.empty []))
+  · exact evalS.print_err
+      (hA := evalA.div_by_zero
+        (h1 := evalA.const 1 State.empty [])
+        (h2 := evalA.const 0 State.empty []))
 
 end Smoke
 

--- a/Imp/HW3/README.md
+++ b/Imp/HW3/README.md
@@ -1,0 +1,63 @@
+# CS522 HW3 in Lean 4 — IMP++
+
+CS522 HW3 asks us to combine the five IMP extensions (increment,
+input-output, halting, threads, locals) into **IMP++** and provide a
+**type system (big-step)**, a **small-step SOS**, and **one of** big-step
+SOS or denotational semantics.
+
+To keep PRs independently reviewable under the mega-QA protocol, we land
+HW3 as **several sequential PRs**:
+
+| Part   | Scope                                               | Status          |
+|--------|-----------------------------------------------------|-----------------|
+| HW3a   | IMP++ **Syntax** + **Big-Step SOS**                 | this PR          |
+| HW3b   | IMP++ **Small-Step SOS** — faithful `spawn` concurrency | follow-up     |
+| HW3c   | IMP++ **Denotational** (above-spec bonus)           | follow-up       |
+| HW3d   | IMP++ **Type-System (big-step)**                    | follow-up       |
+
+## Files in this PR
+
+| File                          | Maps to (Maude)                                                                             |
+|-------------------------------|---------------------------------------------------------------------------------------------|
+| `Imp/HW3/Syntax.lean`         | `HW3/6-imp++/imp-syntax.maude` (+ `state.maude` + `buffer.maude`)                            |
+| `Imp/HW3/BigStep.lean`        | `HW3/6-imp++/big_step/imp-semantics-bigstep.maude`                                          |
+| `Imp/HW3.lean`                | aggregate                                                                                    |
+
+## Design summary
+
+### Syntax additions (from IMP to IMP++)
+
+* `Aexp.read` — read-from-input expression
+* `Stmt.halt` — abrupt-termination statement
+* `Stmt.spawn : Stmt → Stmt` — thread-spawning (modeled sequentially at big-step; see below)
+* `Stmt.intDecl : List Id → Stmt` — local variable declaration as a Stmt
+* `Stmt.print : Aexp → Stmt` — output statement
+* `Stmt.letIn : Id → Aexp → Stmt → Stmt` — desugared form for locals
+
+### Result domains
+
+Maude's `(State, Buffer_in, Buffer_out)` trio + `<error, …>` and
+`<halting, …>` become three inductives:
+
+* `AResult = num Int σ inB | err σ inB`
+* `BResult = bool Bool σ inB | err σ inB`
+* `SResult = state σ inB outB | err σ inB | halted σ inB outB`
+
+### Honest deviations from Maude (flagged)
+
+1. **`spawn { S }` reduced sequentially** at big-step level — see the file
+   docstring. Concurrent semantics requires small-step and lands in HW3b.
+2. **No lexical-scope restoration** on `let X = A in S` exit at big-step.
+   Small-step (HW3b) is the natural place for that.
+3. **Empty-input `read()` is `err`** — Maude does not specify; we pick
+   `err` for determinism in Lean. Revisit once the small-step port is in.
+
+## Verification status
+
+* `lake build` passes (3114 jobs).
+* Smoke examples in `BigStep.lean` cover `halt;`, `print(1);`, and
+  `read()` with non-empty input buffer.
+* Behavioural verification against the Maude `imp-bigstep.maude` /
+  `imp-programs.maude` battery: not run (no local maude binary).
+* Independent review requested from Stepan Nesterov per
+  `experiments/02_do_all_cs522_in_Lean/prompt.md`.

--- a/Imp/HW3/README.md
+++ b/Imp/HW3/README.md
@@ -41,7 +41,7 @@ Maude's `(State, Buffer_in, Buffer_out)` trio + `<error, …>` and
 
 * `AResult = num Int σ inB | err σ inB`
 * `BResult = bool Bool σ inB | err σ inB`
-* `SResult = state σ inB outB | err σ inB | halted σ inB outB`
+* `SResult = state σ inB outB | err σ inB outB | halted σ inB outB`
 
 ### Honest deviations from Maude (flagged)
 
@@ -51,6 +51,14 @@ Maude's `(State, Buffer_in, Buffer_out)` trio + `<error, …>` and
    Small-step (HW3b) is the natural place for that.
 3. **Empty-input `read()` is `err`** — Maude does not specify; we pick
    `err` for determinism in Lean. Revisit once the small-step port is in.
+
+Non-simplification fidelity notes:
+
+* Statement-level `err` results now carry the current output buffer so a later
+  failure does not erase earlier `print` effects in a sequence.
+* `evalA` includes Maude's alternate right-to-left rules for `+` and `/`, so
+  I/O-sensitive programs such as `read() / read()` admit the same derivations
+  as the reference semantics.
 
 ## Verification status
 

--- a/Imp/HW3/Syntax.lean
+++ b/Imp/HW3/Syntax.lean
@@ -1,0 +1,112 @@
+/-!
+# CS522 HW3 — IMP++ syntax
+
+Lean 4 AST for the IMP++ language of CS522 Homework 3 — the union of the
+five IMP extensions: increment, input/output, halting, threads, locals.
+
+Maude source: `brando90/cs522:HW3/6-imp++/imp-syntax.maude` (commit `3d835de`).
+
+## Over the original IMP we gain
+
+* `halt;`           — abrupt termination (halting extension)
+* `spawn { S }`     — thread spawning (threads extension). In this HW3a port
+  we model `spawn` with *sequential-execution* semantics for the big-step
+  judgement, which is the only honest option at big-step level. A faithful
+  concurrent semantics will live in the small-step follow-up (HW3b).
+* `int xl;`         — local variable declaration as a *statement*
+                      (locals extension). Unlike plain IMP where vars are
+                      declared once at program top level, IMP++ lets you
+                      introduce them inside a block.
+* `read()`          — read-from-input expression (input-output extension)
+* `print(a);`       — write-to-output statement (input-output extension)
+
+Plus a desugaring target `let X = A in S` used by the Maude parse-time
+equations in `IMP-DESUGARED-SYNTAX`; we carry it as an explicit AST
+constructor so Lean users can either build ASTs directly in desugared form
+or work with the surface form and invoke `desugar` below.
+-/
+
+namespace Imp.HW3
+
+/-- Program variable names. -/
+abbrev Id := String
+
+/-- Arithmetic expressions — IMP++ adds `read()`. -/
+inductive Aexp where
+  | const : Int → Aexp
+  | var   : Id  → Aexp
+  | add   : Aexp → Aexp → Aexp
+  | div   : Aexp → Aexp → Aexp
+  | read  : Aexp                          -- ★ IMP++ input extension
+deriving Repr, DecidableEq
+
+/-- Boolean expressions — unchanged from IMP. -/
+inductive Bexp where
+  | b   : Bool → Bexp
+  | le  : Aexp → Aexp → Bexp
+  | not : Bexp → Bexp
+  | and : Bexp → Bexp → Bexp
+deriving Repr, DecidableEq
+
+/-- Statements — IMP++ adds `halt`, `spawn`, `int xl;`, `print(a);`, `let`. -/
+inductive Stmt where
+  | skip    : Stmt
+  | assign  : Id → Aexp → Stmt
+  | seq     : Stmt → Stmt → Stmt
+  | ite     : Bexp → Stmt → Stmt → Stmt
+  | while   : Bexp → Stmt → Stmt
+  | halt    : Stmt                         -- ★ halting extension
+  | spawn   : Stmt → Stmt                  -- ★ threads extension (arg is the spawned block)
+  | intDecl : List Id → Stmt               -- ★ locals extension: `int x, y, z ;`
+  | print   : Aexp → Stmt                  -- ★ output extension
+  | letIn   : Id → Aexp → Stmt → Stmt      -- ★ desugared locals: `let X = A in S`
+deriving Repr, DecidableEq
+
+/-- A complete IMP++ program. Per the Maude syntax, `subsort Stmt < Pgm`:
+a program is just a top-level statement. -/
+abbrev Pgm := Stmt
+
+/-- Program state: partial map from variable names to integers. -/
+abbrev State := Id → Option Int
+
+namespace State
+
+/-- Empty state — no variables bound. -/
+def empty : State := fun _ => none
+
+/-- Point-wise update `σ[n/X]`. -/
+def update (σ : State) (X : Id) (n : Int) : State :=
+  fun Y => if Y = X then some n else σ Y
+
+/-- Remove a variable binding (back to undefined) — used by locals on block exit. -/
+def unbind (σ : State) (X : Id) : State :=
+  fun Y => if Y = X then none else σ Y
+
+/-- Initialise a list of variables all to 0 (matches Maude `Xl |-> 0`). -/
+def initZero : List Id → State → State
+  | [], σ      => σ
+  | X :: Xs, σ => (initZero Xs σ).update X 0
+
+end State
+
+/-! ## Input / Output buffers
+
+The Maude configuration carries two `Buffer` components alongside the
+`State`: an input buffer (consumed by `read()`) and an output buffer
+(appended to by `print`). We model both as `List Int`, with head = next
+to read / most recent output. -/
+
+/-- I/O buffer — a sequence of integers, oldest first. -/
+abbrev Buffer := List Int
+
+namespace Buffer
+
+/-- Empty buffer. -/
+def empty : Buffer := []
+
+/-- Prepend an integer at the tail of the buffer (`append` for output). -/
+def snoc (b : Buffer) (n : Int) : Buffer := b ++ [n]
+
+end Buffer
+
+end Imp.HW3


### PR DESCRIPTION
## Summary

First of a sequence of HW3 PRs. CS522 HW3 is the IMP++ combined language (= IMP + increment + input-output + halting + threads + locals). To keep each PR independently reviewable under mega-QA, we split it into:

| Part | Scope                                                 | Status          |
|------|-------------------------------------------------------|-----------------|
| HW3a | IMP++ **Syntax** + **Big-Step SOS** (this PR)         | here            |
| HW3b | IMP++ **Small-Step SOS** (faithful `spawn`)           | follow-up       |
| HW3c | IMP++ **Denotational** (above-spec bonus)             | follow-up       |
| HW3d | IMP++ **Type-System (big-step)**                      | follow-up       |

Files in this PR:

- `Imp/HW3/Syntax.lean` — IMP++ AST (halt, spawn, intDecl, read, print, letIn) + `State` + `Buffer = List Int`
- `Imp/HW3/BigStep.lean` — big-step SOS with input+output buffers; three `SResult` outcomes (state / err / halted)
- `Imp/HW3/README.md` — Lean-to-Maude file map + honest deviations
- `Imp/HW3.lean` — aggregate

Maude-side course docs are on `brando90/cs522@master` commit [`3d835de`](https://github.com/brando90/cs522/commit/3d835de) (HW3 README + extension overview).

## Honest deviations (flagged in code)

1. **`spawn { S }` sequentialised at big-step.** Faithful concurrent semantics require small-step; lands in HW3b.
2. **No lexical-scope restoration** on `let X = A in S` exit at big-step; that's a small-step concern.
3. **Empty-input `read()` modeled as `err`.** Maude doesn't specify; we pick `err` for determinism. Revisit in HW3b.

## Test plan

- [x] `lake build` passes (3114 jobs).
- [x] Smoke tests: `halt;`, `print(1);` appends to output buffer, `read([42;17])` consumes head.
- [ ] Behavioural verification against `imp-bigstep.maude` battery: not run (no local maude).
- [ ] Independent review from Stepan Nesterov — email will follow on merge.

## Mega QA plan

3-stage CC → Codex → Gemini chain per Rule 10. Posted as PR comments.